### PR TITLE
refactor: server context, new signal api

### DIFF
--- a/packages/fsm/src/base.ts
+++ b/packages/fsm/src/base.ts
@@ -11,7 +11,7 @@ definePackage('@alwatr/signal', __package_version__);
 /**
  * Finite State Machine Base Class
  */
-export abstract class FiniteStateMachineBase<S extends string, E extends string> extends AlwatrObservable<S> {
+export abstract class FiniteStateMachineBase<S extends string, E extends string> extends AlwatrObservable<{state: S}> {
   /**
    * States and transitions config.
    */
@@ -24,20 +24,20 @@ export abstract class FiniteStateMachineBase<S extends string, E extends string>
 
   protected initialState_: S;
 
-  protected override data_: S;
+  protected override message_: {state: S};
 
   constructor(config: {name: string; loggerPrefix?: string; initialState: S}) {
     config.loggerPrefix ??= 'fsm';
     super(config);
-    this.data_ = this.initialState_ = config.initialState;
+    this.message_ = {state: this.initialState_ = config.initialState};
   }
 
   /**
-   * Reset machine to initial state.
+   * Reset machine to initial state without notify.
    */
   protected resetToInitialState_(): void {
     this.logger_.logMethod?.('resetToInitialState_');
-    this.data_ = this.initialState_;
+    this.message_ = {state: this.initialState_};
   }
 
   /**
@@ -52,7 +52,7 @@ export abstract class FiniteStateMachineBase<S extends string, E extends string>
    * Transition finite state machine instance to new state.
    */
   protected async transition_(event: E): Promise<void> {
-    const fromState = this.data_;
+    const fromState = this.message_.state;
     const toState = this.stateRecord_[fromState]?.[event] ?? this.stateRecord_._all?.[event];
 
     this.logger_.logMethodArgs?.('transition_', {fromState, event, toState});
@@ -69,7 +69,7 @@ export abstract class FiniteStateMachineBase<S extends string, E extends string>
 
     if ((await this.shouldTransition_(eventDetail)) !== true) return;
 
-    this.notify_(toState);
+    this.notify_({state: toState});
 
     this.postTransition__(eventDetail);
   }

--- a/packages/fsm/src/fsm.ts
+++ b/packages/fsm/src/fsm.ts
@@ -7,8 +7,8 @@ export abstract class FiniteStateMachine<S extends string, E extends string> ext
   /**
    * Current state.
    */
-  getState(): S {
-    return this.data_;
+  get state(): S {
+    return this.message_.state;
   }
 
   /**

--- a/packages/server-context/src/api-request.ts
+++ b/packages/server-context/src/api-request.ts
@@ -14,7 +14,7 @@ export abstract class AlwatrApiRequestBase<
 > extends AlwatrServerRequestBase<ExtraState, ExtraEvent> {
   protected _responseJson?: T;
 
-  protected override async _$fetch(options: FetchOptions): Promise<void> {
+  protected override async fetch__(options: FetchOptions): Promise<void> {
     if (!NODE_MODE) {
       options.headers ??= {};
       if (!options.headers['client-id']) {
@@ -22,11 +22,11 @@ export abstract class AlwatrApiRequestBase<
       }
     }
 
-    await super._$fetch(options);
+    await super.fetch__(options);
 
     let responseText: string;
     try {
-      responseText = await this._response!.text();
+      responseText = await this.response_!.text();
     }
     catch (err) {
       this._logger.error('_$fetch', 'invalid_response_text', err);
@@ -54,8 +54,8 @@ export abstract class AlwatrApiRequestBase<
     }
   }
 
-  protected override _reset(): void {
-    super._reset();
+  protected override resetToInitialState_(): void {
+    super.resetToInitialState_();
     delete this._responseJson;
   }
 }
@@ -73,14 +73,14 @@ export class AlwatrApiRequest<T extends AlwatrServiceResponse = AlwatrServiceRes
   }
 
   get _fetchResponse(): Response | undefined {
-    return this._response;
+    return this.response_;
   }
 
   request(options?: Partial<FetchOptions>): void {
-    return this._request(options);
+    return this.request_(options);
   }
 
   cleanup(): void {
-    this._reset();
+    this.resetToInitialState_();
   }
 }

--- a/packages/server-context/src/server-context.ts
+++ b/packages/server-context/src/server-context.ts
@@ -14,10 +14,10 @@ export abstract class AlwatrServerContextBase<
   T extends AlwatrServiceResponse = AlwatrServiceResponse,
 > extends AlwatrApiRequestBase<T, ExtraState, ExtraEvent> {
   protected _context?: T;
-  constructor(protected override _config: ServerRequestConfig) {
-    super(_config);
+  constructor(protected override config_: ServerRequestConfig) {
+    super(config_);
 
-    this._stateRecord = {
+    this.stateRecord_ = {
       initial: {
         request: 'offlineCheck',
       },
@@ -57,7 +57,7 @@ export abstract class AlwatrServerContextBase<
       },
     };
 
-    this._actionRecord = {
+    this.actionRecord_ = {
       _on_offlineCheck_enter: this._$offlineRequestAction,
       _on_loading_enter: this._$onlineRequestAction,
       _on_reloading_enter: this._$onlineRequestAction,
@@ -66,24 +66,24 @@ export abstract class AlwatrServerContextBase<
   }
 
   protected _$offlineRequestAction(): void {
-    this._logger.logMethod?.('_$offlineRequestAction');
-    this._$fetchOptions!.cacheStrategy === 'cache_only';
-    this._$requestAction();
+    this.logger_.logMethod?.('_$offlineRequestAction');
+    this.fetchOptions__!.cacheStrategy === 'cache_only';
+    this.requestAction__();
   }
 
   protected _$onlineRequestAction(): void {
-    this._logger.logMethod?.('_$onlineRequestAction');
-    this._$fetchOptions!.cacheStrategy === 'update_cache';
-    this._$requestAction();
+    this.logger_.logMethod?.('_$onlineRequestAction');
+    this.fetchOptions__!.cacheStrategy === 'update_cache';
+    this.requestAction__();
   }
 
   protected _$updateContextAction(): void {
     if (this._responseJson === undefined) {
-      this._logger.accident('_$updateContextAction', 'no_response_json');
+      this.logger_.accident('_$updateContextAction', 'no_response_json');
       return;
     }
 
-    this._logger.logMethod?.('_$updateContextAction');
+    this.logger_.logMethod?.('_$updateContextAction');
 
     if (
       this._context === undefined ||
@@ -96,15 +96,15 @@ export abstract class AlwatrServerContextBase<
     this._cleanup();
   }
 
-  protected override async _$requestAction(): Promise<void> {
-    this._logger.logMethod?.('_$requestAction');
+  protected override async requestAction__(): Promise<void> {
+    this.logger_.logMethod?.('_$requestAction');
 
     try {
-      if (this._$fetchOptions === undefined) {
+      if (this.fetchOptions__ === undefined) {
         throw new Error('invalid_fetch_options');
       }
 
-      await this._$fetch(this._$fetchOptions);
+      await this.fetch__(this.fetchOptions__);
 
       this._transition('requestSuccess');
     }
@@ -113,14 +113,14 @@ export abstract class AlwatrServerContextBase<
         this._transition('cacheNotFound');
       }
       else {
-        this._logger.error('_$requestAction', 'fetch_failed', err);
+        this.logger_.error('_$requestAction', 'fetch_failed', err);
         this._transition('requestFailed');
       }
     }
   }
 
   protected _cleanup(): void {
-    delete this._response;
+    delete this.response_;
     delete this._responseJson;
   }
 }
@@ -140,6 +140,6 @@ export class AlwatrServerContext<
   }
 
   request(options?: Partial<FetchOptions>): void {
-    return this._request(options);
+    return this.request_(options);
   }
 }

--- a/packages/signal/src/context.ts
+++ b/packages/signal/src/context.ts
@@ -17,7 +17,7 @@ export class AlwatrContext<T extends Dictionary> extends AlwatrObservable<T> {
    * Return undefined if context not set before or expired.
    */
   getValue(): T | undefined {
-    return this.data_;
+    return this.message_;
   }
 
   /**
@@ -34,7 +34,7 @@ export class AlwatrContext<T extends Dictionary> extends AlwatrObservable<T> {
    * `receivePrevious` in new subscribers not work until new context changes.
    */
   expire(): void {
-    super.clearData_();
+    super.clearMessage_();
   }
 
   /**

--- a/packages/signal/src/signal.ts
+++ b/packages/signal/src/signal.ts
@@ -1,9 +1,11 @@
 import {AlwatrObservable} from './observable.js';
 
+import type { Dictionary } from '@alwatr/type-helper';
+
 /**
- * Alwatr event signal.
+ * Alwatr event signal with special message (event detail).
  */
-export class AlwatrSignal<T> extends AlwatrObservable<T> {
+export class AlwatrSignal<T extends Dictionary = Dictionary> extends AlwatrObservable<T> {
   constructor(config: {name: string; loggerPrefix?: string}) {
     config.loggerPrefix ??= 'signal';
     super(config);
@@ -12,8 +14,8 @@ export class AlwatrSignal<T> extends AlwatrObservable<T> {
   /**
    * Dispatch an event to all listeners.
    */
-  notify(detail: T): void {
-    this.notify_(detail);
+  notify(message: T): void {
+    this.notify_(message);
   }
 
   /**

--- a/packages/signal/src/simple-signal.ts
+++ b/packages/signal/src/simple-signal.ts
@@ -1,9 +1,9 @@
 import {AlwatrObservable} from './observable.js';
 
 /**
- * Alwatr event signal without any data.
+ * Alwatr event signal without any message (no event detail).
  */
-export class AlwatrSimpleSignal extends AlwatrObservable<undefined> {
+export class AlwatrSimpleSignal extends AlwatrObservable {
   constructor(config: {name: string; loggerPrefix?: string}) {
     config.loggerPrefix ??= 'signal';
     super(config);
@@ -13,13 +13,13 @@ export class AlwatrSimpleSignal extends AlwatrObservable<undefined> {
    * Dispatch an event to all listeners.
    */
   notify(): void {
-    this.notify_(undefined);
+    this.notify_({});
   }
 
   /**
    * Wait until next event signal.
    */
-  untilNewNotify(): Promise<void> {
-    return super.untilNewNotify_();
+  async untilNewNotify(): Promise<void> {
+    await super.untilNewNotify_();
   }
 }

--- a/packages/signal/src/type.ts
+++ b/packages/signal/src/type.ts
@@ -1,4 +1,4 @@
-import type {MaybePromise} from '@alwatr/type-helper';
+import type {Dictionary, MaybePromise} from '@alwatr/type-helper';
 
 /**
  * Subscribe options type.
@@ -30,10 +30,10 @@ export interface SubscribeOptions {
   // debounce?: 'AnimationFrame' | number;
 }
 
-export type ListenerCallback<T, D> = (this: T, detail: D) => MaybePromise<void>;
+export type ListenerCallback<T, M extends Dictionary = Dictionary> = (this: T, message: M) => MaybePromise<void>;
 
-export interface Observer<T, D> {
-  callback: ListenerCallback<T, D>;
+export interface Observer<T, M extends Dictionary = Dictionary> {
+  callback: ListenerCallback<T, M>;
   options: SubscribeOptions;
 }
 
@@ -41,7 +41,7 @@ export interface SubscribeResult {
   unsubscribe: () => void;
 }
 
-export interface AlwatrObservableInterface<T> {
+export interface AlwatrObservableInterface<T extends Dictionary = Dictionary> {
   subscribe(listenerCallback: ListenerCallback<this, T>, options?: SubscribeOptions): SubscribeResult;
   unsubscribe(listenerCallback: ListenerCallback<this, T>): void;
 }


### PR DESCRIPTION
- **feat: update all repo files from alwatr**
- **deps: update**
- **deps: bump github/codeql-action**
- **refactor: Update repository name and description**
- **refactor: Update AlwatrContextSignal to AlwatrContext**
- **deps: update**
- **refactor(signal): AlwatrContext to use class property instead of calling super.getData_()**
- **refactor(signal): Update AlwatrContext to use class property instead of calling super.getData_()**
- **refactor(server-context): rename main**
- **refactor(fsm): Update FiniteStateMachineBase class**
- **refactor(fsm): Update FiniteStateMachineBase class to use class property for state and transition methods**
- **refactor(fsm): rename main**
- **refactor(fsm): Update import statement for type.ts**
- **refactor(server-context): Update import statements and package version in server-request.ts**
- **refactor(signal): Remove reference to api-server in tsconfig.json**
- **deps: bump the alwatr-dependencies group with 6 updates**
- **refactor(fsm): Update FiniteStateMachineBase state property to message**
- **refactor(server-request): complete refactor all name and methods to new structures**
- **refactor(server-request): complete refactor all name and methods to new structures**
- **refactor: AlwatrObservable to use 'message' instead of 'data'**
- **refactor: Update AlwatrContext to use 'message' instead of 'data'**
- **refactor: Update AlwatrSignal and AlwatrSimpleSignal to use 'message' instead of 'data'**
- **fix(signal): types**
