### PR TITLE
Enhance FSM: Remove Redundant Initial State, Ensure Post-Transition Execution, and Update Naming

### DIFF
--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -56,7 +56,7 @@
     "clean": "rm -rfv dist *.tsbuildinfo"
   },
   "dependencies": {
-    "@alwatr/nanolib": "^5.0.0",
+    "@alwatr/nanolib": "^5.1.0",
     "@alwatr/observable": "workspace:^"
   },
   "devDependencies": {
@@ -64,7 +64,7 @@
     "@alwatr/prettier-config": "^5.0.0",
     "@alwatr/tsconfig-base": "^5.0.0",
     "@alwatr/type-helper": "^5.0.0",
-    "@types/node": "^22.8.6",
+    "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "typescript": "^5.6.3"
   }

--- a/packages/fetch-state-machine/package.json
+++ b/packages/fetch-state-machine/package.json
@@ -58,14 +58,14 @@
   },
   "dependencies": {
     "@alwatr/fsm": "workspace:^",
-    "@alwatr/nanolib": "^5.0.0"
+    "@alwatr/nanolib": "^5.1.0"
   },
   "devDependencies": {
     "@alwatr/nano-build": "^5.0.0",
     "@alwatr/prettier-config": "^5.0.0",
     "@alwatr/tsconfig-base": "^5.0.0",
     "@alwatr/type-helper": "^5.0.0",
-    "@types/node": "^22.8.6",
+    "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "typescript": "^5.6.3"
   }

--- a/packages/fetch-state-machine/src/base.ts
+++ b/packages/fetch-state-machine/src/base.ts
@@ -4,7 +4,7 @@ import {packageTracer, fetch, type FetchOptions} from '@alwatr/nanolib';
 __dev_mode__: packageTracer.add(__package_name__, __package_version__);
 
 export type ServerRequestState = 'initial' | 'loading' | 'failed' | 'complete';
-export type ServerRequestEvent = 'request' | 'requestFailed' | 'requestSucceeded';
+export type ServerRequestEvent = 'request' | 'request_failed' | 'request_succeeded';
 
 export type {FetchOptions};
 
@@ -25,8 +25,8 @@ export abstract class AlwatrFetchStateMachineBase<
       request: 'loading',
     },
     loading: {
-      requestFailed: 'failed',
-      requestSucceeded: 'complete',
+      request_failed: 'failed',
+      request_succeeded: 'complete',
     },
     failed: {
       request: 'loading',
@@ -37,7 +37,7 @@ export abstract class AlwatrFetchStateMachineBase<
   } as StateRecord<ServerRequestState | ExtraState, ServerRequestEvent | ExtraEvent>;
 
   protected override actionRecord_ = {
-    on_loading_enter: this.requestAction_,
+    on_state_loading_enter: this.requestAction_,
   } as ActionRecord<ServerRequestState | ExtraState, ServerRequestEvent | ExtraEvent>;
 
   constructor(config: AlwatrFetchStateMachineConfig<ServerRequestState | ExtraState>) {
@@ -83,12 +83,12 @@ export abstract class AlwatrFetchStateMachineBase<
 
   protected requestSucceeded_(): void {
     this.logger_.logMethod?.('requestSucceeded_');
-    this.transition_('requestSucceeded');
+    this.transition_('request_succeeded');
   }
 
   protected requestFailed_(error: Error): void {
     this.logger_.error('requestFailed_', 'fetch_failed', error);
-    this.transition_('requestFailed');
+    this.transition_('request_failed');
   }
 
   protected setFetchOptions_(options?: Partial<FetchOptions>): void {

--- a/packages/fetch-state-machine/src/base.ts
+++ b/packages/fetch-state-machine/src/base.ts
@@ -1,9 +1,4 @@
-import {
-  AlwatrFluxStateMachineBase,
-  type StateRecord,
-  type ActionRecord,
-  type AlwatrFluxStateMachineConfig
-} from '@alwatr/fsm';
+import {AlwatrFluxStateMachineBase, type StateRecord, type ActionRecord, type AlwatrFluxStateMachineConfig} from '@alwatr/fsm';
 import {packageTracer, fetch, type FetchOptions} from '@alwatr/nanolib';
 
 __dev_mode__: packageTracer.add(__package_name__, __package_version__);
@@ -13,7 +8,7 @@ export type ServerRequestEvent = 'request' | 'requestFailed' | 'requestSucceeded
 
 export type {FetchOptions};
 
-export interface AlwatrFetchStateMachineConfig<S extends string> extends AlwatrFluxStateMachineConfig<S> {
+export interface AlwatrFetchStateMachineConfig<S extends string> extends Omit<AlwatrFluxStateMachineConfig<S>, 'initialState'> {
   fetch: Partial<FetchOptions>;
 }
 
@@ -47,7 +42,10 @@ export abstract class AlwatrFetchStateMachineBase<
 
   constructor(config: AlwatrFetchStateMachineConfig<ServerRequestState | ExtraState>) {
     config.loggerPrefix ??= 'fetch-state-machine';
-    super(config);
+    super({
+      ...config,
+      initialState: 'initial',
+    });
     this.baseFetchOptions_ = config.fetch;
   }
 

--- a/packages/flux/package.json
+++ b/packages/flux/package.json
@@ -68,7 +68,7 @@
     "@alwatr/prettier-config": "^5.0.0",
     "@alwatr/tsconfig-base": "^5.0.0",
     "@alwatr/type-helper": "^5.0.0",
-    "@types/node": "^22.8.6",
+    "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "typescript": "^5.6.3"
   }

--- a/packages/fsm/package.json
+++ b/packages/fsm/package.json
@@ -58,7 +58,7 @@
     "clean": "rm -rfv dist *.tsbuildinfo"
   },
   "dependencies": {
-    "@alwatr/nanolib": "^5.0.0",
+    "@alwatr/nanolib": "^5.1.0",
     "@alwatr/observable": "workspace:^"
   },
   "devDependencies": {
@@ -66,7 +66,7 @@
     "@alwatr/prettier-config": "^5.0.0",
     "@alwatr/tsconfig-base": "^5.0.0",
     "@alwatr/type-helper": "^5.0.0",
-    "@types/node": "^22.8.6",
+    "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "typescript": "^5.6.3"
   }

--- a/packages/fsm/src/base.ts
+++ b/packages/fsm/src/base.ts
@@ -1,18 +1,18 @@
 import {packageTracer} from '@alwatr/nanolib';
 import {AlwatrObservable, type AlwatrObservableConfig} from '@alwatr/observable';
 
-import type {ActionName, ActionRecord, MachineEvent, MachineState, StateEventDetail, StateRecord} from './type.js';
+import type {ActionName, ActionRecord, StateEventDetail, StateRecord} from './type.js';
 
 __dev_mode__: packageTracer.add(__package_name__, __package_version__);
 
-export interface AlwatrFluxStateMachineConfig<S extends MachineState> extends AlwatrObservableConfig {
+export interface AlwatrFluxStateMachineConfig<S extends string> extends AlwatrObservableConfig {
   initialState: S;
 }
 
 /**
  * Flux (Finite) State Machine Base Class
  */
-export abstract class AlwatrFluxStateMachineBase<S extends MachineState, E extends MachineEvent> extends AlwatrObservable<{state: S}> {
+export abstract class AlwatrFluxStateMachineBase<S extends string, E extends string> extends AlwatrObservable<{state: S}> {
   /**
    * States and transitions config.
    */
@@ -45,7 +45,7 @@ export abstract class AlwatrFluxStateMachineBase<S extends MachineState, E exten
     this.message_ = {state: this.initialState_};
     this.postTransition__({
       from,
-      event: 'reset' as E,
+      event: 'reset',
       to: this.initialState_,
     });
   }
@@ -63,7 +63,7 @@ export abstract class AlwatrFluxStateMachineBase<S extends MachineState, E exten
    */
   protected async transition_(event: E): Promise<void> {
     const fromState = this.message_.state;
-    const toState = this.stateRecord_[fromState]?.[event] ?? this.stateRecord_._all?.[event];
+    const toState = this.stateRecord_[fromState]?.[event];
 
     this.logger_.logMethodArgs?.('transition_', {fromState, event, toState});
 
@@ -79,7 +79,7 @@ export abstract class AlwatrFluxStateMachineBase<S extends MachineState, E exten
 
     if ((await this.shouldTransition_(eventDetail)) !== true) return;
 
-    this.notify_({state: toState});
+    this.notify_({state: toState}); // message update but notify event delayed after execActions.
 
     this.postTransition__(eventDetail);
   }
@@ -90,28 +90,22 @@ export abstract class AlwatrFluxStateMachineBase<S extends MachineState, E exten
   private async postTransition__(eventDetail: StateEventDetail<S, E>): Promise<void> {
     this.logger_.logMethodArgs?.('_transitioned', eventDetail);
 
-    await this.execAction__(`on_${eventDetail.event}`, eventDetail);
+    await this.execAction__(`on_event_${eventDetail.event}`, eventDetail);
 
     if (eventDetail.from !== eventDetail.to) {
-      await this.execAction__(`on_state_exit`, eventDetail);
-      await this.execAction__(`on_${eventDetail.from}_exit`, eventDetail);
-      await this.execAction__(`on_state_enter`, eventDetail);
-      await this.execAction__(`on_${eventDetail.to}_enter`, eventDetail);
+      await this.execAction__(`on_any_state_exit`, eventDetail);
+      await this.execAction__(`on_state_${eventDetail.from}_exit`, eventDetail);
+      await this.execAction__(`on_any_state_enter`, eventDetail);
+      await this.execAction__(`on_state_${eventDetail.to}_enter`, eventDetail);
     }
 
-    if (Object.hasOwn(this, `on_${eventDetail.from}_${eventDetail.event}`)) {
-      this.execAction__(`on_${eventDetail.from}_${eventDetail.event}`, eventDetail);
-    }
-    else {
-      // The action `all_eventName` is executed only if the action `fromState_eventName` is not defined.
-      this.execAction__(`on_all_${eventDetail.event}`, eventDetail);
-    }
+    this.execAction__(`on_state_${eventDetail.from}_event_${eventDetail.event}`, eventDetail);
   }
 
   /**
    * Execute action name if defined in _actionRecord.
    */
-  private execAction__(name: ActionName<S, E>, eventDetail: StateEventDetail<S, E>): MaybePromise<void> {
+  private execAction__(name: ActionName<S, E | 'reset'>, eventDetail: StateEventDetail<S, E>): MaybePromise<void> {
     const actionFn = this.actionRecord_[name];
     if (typeof actionFn === 'function') {
       this.logger_.logMethodArgs?.('_$execAction', name);

--- a/packages/fsm/src/type.ts
+++ b/packages/fsm/src/type.ts
@@ -1,20 +1,19 @@
-export interface StateEventDetail<S, E> {
+export interface StateEventDetail<S extends string, E extends string> {
   from: S;
-  event: E;
+  event: E | 'reset';
   to: S;
 }
 
-export type StateRecord<S extends string, E extends string> = Partial<Record<S | '_all', Partial<Record<E, S>>>>;
+export type StateRecord<S extends string, E extends string> = Partial<Record<S, Partial<Record<E | 'reset', S>>>>;
 
-export type Action<S extends string, E extends string> = (eventDetail?: StateEventDetail<S, E>) => MaybePromise<void>;
+export type Action<S extends string, E extends string> = (eventDetail?: StateEventDetail<S, E | 'reset'>) => MaybePromise<void>;
 
 export type ActionName<S extends string, E extends string> =
-  | `on_${E}`
-  | `on_state_exit`
-  | `on_state_enter`
-  | `on_${S}_exit`
-  | `on_${S}_enter`
-  | `on_${S}_${E}`
-  | `on_all_${E}`;
+  | `on_event_${E}`
+  | `on_any_state_exit`
+  | `on_any_state_enter`
+  | `on_state_${S}_exit`
+  | `on_state_${S}_enter`
+  | `on_state_${S}_event_${E}`;
 
-export type ActionRecord<S extends string, E extends string> = Partial<Record<ActionName<S, E>, Action<S, E>>>;
+export type ActionRecord<S extends string, E extends string> = Partial<Record<ActionName<S, E | 'reset'>, Action<S, E | 'reset'>>>;

--- a/packages/observable/package.json
+++ b/packages/observable/package.json
@@ -56,14 +56,14 @@
     "clean": "rm -rfv dist *.tsbuildinfo"
   },
   "dependencies": {
-    "@alwatr/nanolib": "^5.0.0"
+    "@alwatr/nanolib": "^5.1.0"
   },
   "devDependencies": {
     "@alwatr/nano-build": "^5.0.0",
     "@alwatr/prettier-config": "^5.0.0",
     "@alwatr/tsconfig-base": "^5.0.0",
     "@alwatr/type-helper": "^5.0.0",
-    "@types/node": "^22.8.6",
+    "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "typescript": "^5.6.3"
   }

--- a/packages/observable/src/observable.ts
+++ b/packages/observable/src/observable.ts
@@ -1,4 +1,4 @@
-import {createLogger, packageTracer} from '@alwatr/nanolib';
+import {createLogger, packageTracer, type AlwatrLogger} from '@alwatr/nanolib';
 
 import type {SubscribeOptions, ListenerCallback, Observer, SubscribeResult, AlwatrObservableInterface} from './type.js';
 
@@ -11,7 +11,7 @@ export interface AlwatrObservableConfig {
 
 export abstract class AlwatrObservable<T extends DictionaryOpt = DictionaryOpt> implements AlwatrObservableInterface<T> {
   protected name_;
-  protected logger_;
+  protected logger_: AlwatrLogger;
   protected message_?: T;
   protected observers__: Observer<this, T>[] = [];
 

--- a/packages/remote-context/package.json
+++ b/packages/remote-context/package.json
@@ -60,14 +60,14 @@
   },
   "dependencies": {
     "@alwatr/fetch-state-machine": "workspace:^",
-    "@alwatr/nanolib": "^5.0.0"
+    "@alwatr/nanolib": "^5.1.0"
   },
   "devDependencies": {
     "@alwatr/nano-build": "^5.0.0",
     "@alwatr/prettier-config": "^5.0.0",
     "@alwatr/tsconfig-base": "^5.0.0",
     "@alwatr/type-helper": "^5.0.0",
-    "@types/node": "^22.8.6",
+    "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "typescript": "^5.6.3"
   }

--- a/packages/remote-context/src/base.ts
+++ b/packages/remote-context/src/base.ts
@@ -8,10 +8,10 @@ import {packageTracer} from '@alwatr/nanolib';
 
 __dev_mode__: packageTracer.add(__package_name__, __package_version__);
 
-type ExtraState = 'offlineCheck' | 'reloading' | 'reloadingFailed';
+type ExtraState = 'offline_check' | 'reloading' | 'reloading_failed';
 export type ServerContextState = ServerRequestState | ExtraState;
 
-type ExtraEvent = 'cacheNotFound';
+type ExtraEvent = 'cache_not_found';
 export type ServerContextEvent = ServerRequestEvent | ExtraEvent;
 
 export type AlwatrRemoteContextStateMachineConfig = AlwatrFetchStateMachineConfig<ServerContextState>;
@@ -28,37 +28,37 @@ export abstract class AlwatrRemoteContextStateMachineBase<T extends Json = Json>
 
     this.stateRecord_ = {
       initial: {
-        request: 'offlineCheck',
+        request: 'offline_check',
       },
       /**
        * Just check offline cache data before online request.
        */
-      offlineCheck: {
-        requestFailed: 'failed',
-        cacheNotFound: 'loading',
-        requestSucceeded: 'reloading',
+      offline_check: {
+        request_failed: 'failed',
+        cache_not_found: 'loading',
+        request_succeeded: 'reloading',
       },
       /**
        * First loading without any cached context.
        */
       loading: {
-        requestFailed: 'failed',
-        requestSucceeded: 'complete',
+        request_failed: 'failed',
+        request_succeeded: 'complete',
       },
       /**
        * First loading failed without any cached context.
        */
       failed: {
-        request: 'loading', // //TODO: why offlineCheck? should be loading!
+        request: 'loading', // //TODO: why offline_check? should be loading!
       },
       reloading: {
-        requestFailed: 'reloadingFailed',
-        requestSucceeded: 'complete',
+        request_failed: 'reloading_failed',
+        request_succeeded: 'complete',
       },
       /**
        * Reloading failed with previously cached context exist.
        */
-      reloadingFailed: {
+      reloading_failed: {
         request: 'reloading',
       },
       complete: {
@@ -67,10 +67,10 @@ export abstract class AlwatrRemoteContextStateMachineBase<T extends Json = Json>
     };
 
     this.actionRecord_ = {
-      on_offlineCheck_enter: this.offlineRequestAction_,
-      on_loading_enter: this.onlineRequestAction_,
-      on_reloading_enter: this.onlineRequestAction_,
-      on_requestSucceeded: this.updateContextAction_,
+      on_state_offline_check_enter: this.offlineRequestAction_,
+      on_state_loading_enter: this.onlineRequestAction_,
+      on_state_reloading_enter: this.onlineRequestAction_,
+      on_event_request_succeeded: this.updateContextAction_,
     };
   }
 
@@ -101,7 +101,7 @@ export abstract class AlwatrRemoteContextStateMachineBase<T extends Json = Json>
     this.logger_.logMethod?.('requestFailed_');
 
     if (error.message === 'fetch_cache_not_found') {
-      this.transition_('cacheNotFound');
+      this.transition_('cache_not_found');
     }
     else {
       super.requestFailed_(error);

--- a/packages/signal/package.json
+++ b/packages/signal/package.json
@@ -56,7 +56,7 @@
     "clean": "rm -rfv dist *.tsbuildinfo"
   },
   "dependencies": {
-    "@alwatr/nanolib": "^5.0.0",
+    "@alwatr/nanolib": "^5.1.0",
     "@alwatr/observable": "workspace:^"
   },
   "devDependencies": {
@@ -64,7 +64,7 @@
     "@alwatr/prettier-config": "^5.0.0",
     "@alwatr/tsconfig-base": "^5.0.0",
     "@alwatr/type-helper": "^5.0.0",
-    "@types/node": "^22.8.6",
+    "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "typescript": "^5.6.3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,12 +20,12 @@ __metadata:
   resolution: "@alwatr/context@workspace:packages/context"
   dependencies:
     "@alwatr/nano-build": "npm:^5.0.0"
-    "@alwatr/nanolib": "npm:^5.0.0"
+    "@alwatr/nanolib": "npm:^5.1.0"
     "@alwatr/observable": "workspace:^"
     "@alwatr/prettier-config": "npm:^5.0.0"
     "@alwatr/tsconfig-base": "npm:^5.0.0"
     "@alwatr/type-helper": "npm:^5.0.0"
-    "@types/node": "npm:^22.8.6"
+    "@types/node": "npm:^22.9.0"
     jest: "npm:^29.7.0"
     typescript: "npm:^5.6.3"
   languageName: unknown
@@ -103,11 +103,11 @@ __metadata:
   dependencies:
     "@alwatr/fsm": "workspace:^"
     "@alwatr/nano-build": "npm:^5.0.0"
-    "@alwatr/nanolib": "npm:^5.0.0"
+    "@alwatr/nanolib": "npm:^5.1.0"
     "@alwatr/prettier-config": "npm:^5.0.0"
     "@alwatr/tsconfig-base": "npm:^5.0.0"
     "@alwatr/type-helper": "npm:^5.0.0"
-    "@types/node": "npm:^22.8.6"
+    "@types/node": "npm:^22.9.0"
     jest: "npm:^29.7.0"
     typescript: "npm:^5.6.3"
   languageName: unknown
@@ -159,7 +159,7 @@ __metadata:
     "@alwatr/signal": "workspace:^"
     "@alwatr/tsconfig-base": "npm:^5.0.0"
     "@alwatr/type-helper": "npm:^5.0.0"
-    "@types/node": "npm:^22.8.6"
+    "@types/node": "npm:^22.9.0"
     jest: "npm:^29.7.0"
     typescript: "npm:^5.6.3"
   languageName: unknown
@@ -170,12 +170,12 @@ __metadata:
   resolution: "@alwatr/fsm@workspace:packages/fsm"
   dependencies:
     "@alwatr/nano-build": "npm:^5.0.0"
-    "@alwatr/nanolib": "npm:^5.0.0"
+    "@alwatr/nanolib": "npm:^5.1.0"
     "@alwatr/observable": "workspace:^"
     "@alwatr/prettier-config": "npm:^5.0.0"
     "@alwatr/tsconfig-base": "npm:^5.0.0"
     "@alwatr/type-helper": "npm:^5.0.0"
-    "@types/node": "npm:^22.8.6"
+    "@types/node": "npm:^22.9.0"
     jest: "npm:^29.7.0"
     typescript: "npm:^5.6.3"
   languageName: unknown
@@ -238,9 +238,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@alwatr/nanolib@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@alwatr/nanolib@npm:5.0.0"
+"@alwatr/nanolib@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "@alwatr/nanolib@npm:5.1.0"
   dependencies:
     "@alwatr/async-queue": "npm:^5.0.0"
     "@alwatr/dedupe": "npm:^5.0.0"
@@ -256,26 +256,26 @@ __metadata:
     "@alwatr/is-number": "npm:^5.0.0"
     "@alwatr/local-storage": "npm:^5.0.0"
     "@alwatr/logger": "npm:^5.0.0"
-    "@alwatr/node-fs": "npm:^5.0.0"
+    "@alwatr/node-fs": "npm:^5.1.0"
     "@alwatr/package-tracer": "npm:^5.0.0"
     "@alwatr/parse-duration": "npm:^5.0.0"
     "@alwatr/platform-info": "npm:^5.0.0"
     "@alwatr/render-state": "npm:^5.0.0"
     "@alwatr/resolve-url": "npm:^5.0.0"
     "@alwatr/unicode-digits": "npm:^5.0.0"
-  checksum: 10c0/8b31422f988db366d33c36b5dafa5c8587022d4980a6dff2551f9fcfff9dc20c45a90fa93a0486f7565da7ef5fae4fca322d30eaa868d404ecadbf1e7667340c
+  checksum: 10c0/200ef402b9052ad68f345f9e7209634cfe3ff5f3ddd40cbc1d7efc7c9b5f01fb8f278f3cf2d6cea12dbc8623d7048e0c0816fb16f96f2b2587b59665e18e67ab
   languageName: node
   linkType: hard
 
-"@alwatr/node-fs@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@alwatr/node-fs@npm:5.0.0"
+"@alwatr/node-fs@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "@alwatr/node-fs@npm:5.1.0"
   dependencies:
     "@alwatr/async-queue": "npm:^5.0.0"
     "@alwatr/flat-string": "npm:^5.0.0"
     "@alwatr/logger": "npm:^5.0.0"
     "@alwatr/package-tracer": "npm:^5.0.0"
-  checksum: 10c0/ea82d3284a8a826bcc636f0ff3e2109def9d41490acbcd3cc461c250df00bc73e733dae8bd4b27da415c40a193ba563b64f81976e4656907b4c3f7f6ecfb2282
+  checksum: 10c0/645ad1c34e5254a36d6b18ce8f687a6107b6212b3e4ca90b5c3bf238e9c37651c7f19b09149ef03fdb845bbe55fbb8459c8272e86b3018e82a3daaabe34351c1
   languageName: node
   linkType: hard
 
@@ -284,11 +284,11 @@ __metadata:
   resolution: "@alwatr/observable@workspace:packages/observable"
   dependencies:
     "@alwatr/nano-build": "npm:^5.0.0"
-    "@alwatr/nanolib": "npm:^5.0.0"
+    "@alwatr/nanolib": "npm:^5.1.0"
     "@alwatr/prettier-config": "npm:^5.0.0"
     "@alwatr/tsconfig-base": "npm:^5.0.0"
     "@alwatr/type-helper": "npm:^5.0.0"
-    "@types/node": "npm:^22.8.6"
+    "@types/node": "npm:^22.9.0"
     jest: "npm:^29.7.0"
     typescript: "npm:^5.6.3"
   languageName: unknown
@@ -342,11 +342,11 @@ __metadata:
   dependencies:
     "@alwatr/fetch-state-machine": "workspace:^"
     "@alwatr/nano-build": "npm:^5.0.0"
-    "@alwatr/nanolib": "npm:^5.0.0"
+    "@alwatr/nanolib": "npm:^5.1.0"
     "@alwatr/prettier-config": "npm:^5.0.0"
     "@alwatr/tsconfig-base": "npm:^5.0.0"
     "@alwatr/type-helper": "npm:^5.0.0"
-    "@types/node": "npm:^22.8.6"
+    "@types/node": "npm:^22.9.0"
     jest: "npm:^29.7.0"
     typescript: "npm:^5.6.3"
   languageName: unknown
@@ -376,12 +376,12 @@ __metadata:
   resolution: "@alwatr/signal@workspace:packages/signal"
   dependencies:
     "@alwatr/nano-build": "npm:^5.0.0"
-    "@alwatr/nanolib": "npm:^5.0.0"
+    "@alwatr/nanolib": "npm:^5.1.0"
     "@alwatr/observable": "workspace:^"
     "@alwatr/prettier-config": "npm:^5.0.0"
     "@alwatr/tsconfig-base": "npm:^5.0.0"
     "@alwatr/type-helper": "npm:^5.0.0"
-    "@types/node": "npm:^22.8.6"
+    "@types/node": "npm:^22.9.0"
     jest: "npm:^29.7.0"
     typescript: "npm:^5.6.3"
   languageName: unknown
@@ -2291,12 +2291,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^22.8.6":
-  version: 22.8.6
-  resolution: "@types/node@npm:22.8.6"
+"@types/node@npm:*, @types/node@npm:^22.9.0":
+  version: 22.9.0
+  resolution: "@types/node@npm:22.9.0"
   dependencies:
     undici-types: "npm:~6.19.8"
-  checksum: 10c0/d3a11f2549234a91a4c5d0ff35ab4bdcb7ba34db4d3f1d189be39b8bd41c19aac98d117150a95a9c5a9d45b1014135477ea240b2b8317c86ae3d3cf1c3b3f8f4
+  checksum: 10c0/3f46cbe0a49bab4ba30494025e4c8a6e699b98ac922857aa1f0209ce11a1313ee46e6808b8f13fe5b8b960a9d7796b77c8d542ad4e9810e85ef897d5593b5d51
   languageName: node
   linkType: hard
 
@@ -2985,9 +2985,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001669":
-  version: 1.0.30001676
-  resolution: "caniuse-lite@npm:1.0.30001676"
-  checksum: 10c0/53d310d76b5282947c99638a65d7534ac28a80aae1920de085a616ec8ad603358fad67cebacfc0452b1efdea12cce24fd37a50a712d074986b4962110e87d82b
+  version: 1.0.30001677
+  resolution: "caniuse-lite@npm:1.0.30001677"
+  checksum: 10c0/22b4aa738b213b5d0bc820c26ba23fa265ca90a5c59776e1a686b9ab6fff9120d0825fd920c0a601a4b65056ef40d01548405feb95c8dd6083255f50c71a0864
   languageName: node
   linkType: hard
 
@@ -3571,9 +3571,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.41":
-  version: 1.5.50
-  resolution: "electron-to-chromium@npm:1.5.50"
-  checksum: 10c0/8b77b18ae833bfe2173e346ac33b8d66b5b5acf0cf5de65df9799f4d482334c938aa0950e4d01391d5fab8994f46c0e9059f4517843e7b8d861f9b0c49eb4c5d
+  version: 1.5.52
+  resolution: "electron-to-chromium@npm:1.5.52"
+  checksum: 10c0/1c85a5710ad21758780b8e067d5f63ed00416dbe93f64bd8937dbfb4ed98cf93d80c471a30daed439cb91a00ff4942ea2628e00a69d56639cc7070e9e8ab2694
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- **fix(fsm): remove initialState from AlwatrFetchStateMachineConfig**
- **fix(fsm): run postTransition__ in resetToInitialState_ and constructor**
- **fix(observable): add AlwatrLogger type to logger_ property**
- **refactor(fsm): update action naming conventions and enhance event handling in state transitions**
