### PR TITLE
Add signal transformation functions and improve resource cleanup

### DIFF
--- a/packages/signal/package.json
+++ b/packages/signal/package.json
@@ -5,7 +5,7 @@
   "author": "S. Ali Mihandoost <ali.mihandoost@gmail.com>",
   "bugs": "https://github.com/Alwatr/flux/issues",
   "dependencies": {
-    "@alwatr/debounce": "^1.0.1",
+    "@alwatr/debounce": "^1.1.0",
     "@alwatr/delay": "^6.0.4",
     "@alwatr/logger": "^6.0.0"
   },

--- a/packages/signal/src/operators/debounce.ts
+++ b/packages/signal/src/operators/debounce.ts
@@ -81,10 +81,12 @@ export function createDebouncedSignal<T>(sourceSignal: IReadonlySignal<T>, confi
     deps: [internalSignal],
     get: () => internalSignal.value,
     onDestroy: () => {
-      debouncer.cancel();
+      if (internalSignal.isDestroyed) return;
       internalSignal.destroy();
+      debouncer.cancel();
       subscription.unsubscribe();
       config.onDestroy?.();
+      config = null as unknown as DebounceSignalConfig;
     },
   });
 }

--- a/packages/signal/src/operators/debounce.ts
+++ b/packages/signal/src/operators/debounce.ts
@@ -82,9 +82,9 @@ export function createDebouncedSignal<T>(sourceSignal: IReadonlySignal<T>, confi
     get: () => internalSignal.value,
     onDestroy: () => {
       if (internalSignal.isDestroyed) return;
-      internalSignal.destroy();
-      debouncer.cancel();
       subscription.unsubscribe();
+      debouncer.cancel();
+      internalSignal.destroy();
       config.onDestroy?.();
       config = null as unknown as DebounceSignalConfig;
     },

--- a/packages/signal/src/operators/filter.ts
+++ b/packages/signal/src/operators/filter.ts
@@ -1,0 +1,77 @@
+import {createComputedSignal} from '../creators/computed.js';
+import {createStateSignal} from '../creators/state.js';
+
+import type {ComputedSignal} from '../core/computed-signal.js';
+import type {IReadonlySignal} from '../type.js';
+
+/**
+ * Creates a new computed signal that only emits values from a source signal
+ * that satisfy a predicate function.
+ *
+ * This operator is analogous to `Array.prototype.filter`. It is particularly
+ * useful for creating effects or other computed signals that should only react
+ * to a specific subset of state changes.
+ *
+ * Note: The resulting signal's value will be `undefined` until the source
+ * emits a value that passes the filter.
+ *
+ * @template T The type of the signal's value.
+ *
+ * @param sourceSignal The original signal to filter.
+ * @param predicate A function that returns `true` if the value should be passed.
+ * @param signalId An optional, unique identifier for the new signal for debugging. default: `${sourceSignal.signalId}-filtered`
+ *
+ * @returns A new computed signal that emits filtered values.
+ *
+ * @example
+ * const numberSignal = createStateSignal({ signalId: 'number', initialValue: 0 });
+ *
+ * const evenNumberSignal = createFilteredSignal(
+ * numberSignal,
+ * (num) => num % 2 === 0,
+ * );
+ *
+ * createEffect({
+ * deps: [evenNumberSignal],
+ * run: () => {
+ * // This effect only runs for even numbers.
+ * // The value can be `undefined` on the first run if initialValue is not even.
+ * if (evenNumberSignal.value !== undefined) {
+ * console.log(`Even number detected: ${evenNumberSignal.value}`);
+ * }
+ * },
+ * runImmediately: true,
+ * });
+ * // Logs: "Even number detected: 0"
+ *
+ * numberSignal.set(1); // Effect does not run
+ * numberSignal.set(2); // Logs: "Even number detected: 2"
+ */
+export function createFilteredSignal<T>(
+  sourceSignal: IReadonlySignal<T>,
+  predicate: (value: T) => boolean,
+  signalId = `${sourceSignal.signalId}-filtered`,
+): ComputedSignal<T | undefined> {
+  const initialValue = predicate(sourceSignal.value) ? sourceSignal.value : undefined;
+
+  const internalSignal = createStateSignal({
+    signalId: `${signalId}-internal`,
+    initialValue,
+  });
+
+  const subscription = sourceSignal.subscribe((newValue) => {
+    if (predicate(newValue)) {
+      internalSignal.set(newValue);
+    }
+  });
+
+  return createComputedSignal({
+    signalId,
+    deps: [internalSignal],
+    get: () => internalSignal.value,
+    onDestroy: () => {
+      subscription.unsubscribe();
+      internalSignal.destroy();
+    },
+  });
+}

--- a/packages/signal/src/operators/map.ts
+++ b/packages/signal/src/operators/map.ts
@@ -1,0 +1,48 @@
+import {createComputedSignal} from '../creators/computed.js';
+
+import type {ComputedSignal} from '../core/computed-signal.js';
+import type {IReadonlySignal} from '../type.js';
+
+/**
+ * Creates a new read-only computed signal that transforms the value of a source
+ * signal using a projection function.
+ *
+ * This operator is analogous to `Array.prototype.map`. It applies a function to
+ * each value emitted by the source signal and emits the result.
+ *
+ * @template T The type of the source signal's value.
+ * @template R The type of the projected value.
+ *
+ * @param sourceSignal The original signal to transform.
+ * @param projectFunction A function to apply to each value from the source signal.
+ * @param [signalId] An optional, unique identifier for the new signal for debugging. default: `${sourceSignal.signalId}-mapped`
+ *
+ * @returns A new, read-only computed signal with the transformed values.
+ *
+ * @example
+ * const userSignal = createStateSignal({
+ *   signalId: 'user',
+ *   initialValue: { name: 'John', age: 30 },
+ * });
+ *
+ * const userNameSignal = createMappedSignal(
+ *   userSignal,
+ *   (user) => user.name,
+ * );
+ *
+ * console.log(userNameSignal.value); // Outputs: "John"
+ * // in next macro-task ...
+ * userSignal.set({ name: 'Jane', age: 32 });
+ * console.log(userNameSignal.value); // Outputs: "Jane"
+ */
+export function createMappedSignal<T, R>(
+  sourceSignal: IReadonlySignal<T>,
+  projectFunction: (value: T) => R,
+  signalId = `${sourceSignal.signalId}-mapped`,
+): ComputedSignal<R> {
+  return createComputedSignal({
+    signalId,
+    deps: [sourceSignal],
+    get: () => projectFunction(sourceSignal.value),
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,10 +5,10 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@alwatr/debounce@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@alwatr/debounce@npm:1.0.1"
-  checksum: 10c0/c53e9ed56c662ff31fa89557fc1288f05a92906f5cee8bd5b54699f8dc32b2718c6cb3ba9942a1b3d4e2b9db5b5eeceda3c65ea5ce95fa43a5ac182a37bbf8da
+"@alwatr/debounce@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@alwatr/debounce@npm:1.1.0"
+  checksum: 10c0/c588ce4c10815cb9642d8a10d6cf5cf0257721f1eddba16eac8c5eb10e15b92c7a50dcfef39b2f1c95e25e626888d5095ddd008e4b301c4b202582fe49b22bae
   languageName: node
   linkType: hard
 
@@ -99,7 +99,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@alwatr/signal@workspace:packages/signal"
   dependencies:
-    "@alwatr/debounce": "npm:^1.0.1"
+    "@alwatr/debounce": "npm:^1.1.0"
     "@alwatr/delay": "npm:^6.0.4"
     "@alwatr/logger": "npm:^6.0.0"
     "@alwatr/nano-build": "npm:^6.1.2"


### PR DESCRIPTION
Introduce `createMappedSignal` and `createFilteredSignal` for transforming and filtering source signal values. Enhance resource cleanup in `createDebouncedSignal` by checking the internal signal state before destruction. Update the `@alwatr/debounce` dependency to version 1.1.0.