### PR TITLE
Refactor signal access methods for clarity and consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ import {ComputedSignal} from '@alwatr/signal';
 const fullName = new ComputedSignal<string>({
   signalId: 'user-fullName',
   deps: [firstName], // This computed signal depends on firstName.
-  get: () => `User: ${firstName.value}`,
+  get: () => `User: ${firstName.get()}`,
 });
 
-console.log(fullName.value); // Outputs: "User: John"
+console.log(fullName.get()); // Outputs: "User: John"
 ```
 
 ### 4. Create an Effect Signal
@@ -90,7 +90,7 @@ import {EffectSignal} from '@alwatr/signal';
 const loggerEffect = new EffectSignal({
   deps: [fullName, counter], // This effect depends on fullName and counter.
   run: () => {
-    console.log(`${fullName.value} has clicked ${counter.value} times.`);
+    console.log(`${fullName.get()} has clicked ${counter.get()} times.`);
   },
 });
 ```
@@ -139,7 +139,7 @@ Signals that depend on other signals (like `ComputedSignal` and `EffectSignal`) 
 // Create a computed signal
 const isEven = new ComputedSignal({
   deps: [counter],
-  get: () => counter.value % 2 === 0,
+  get: () => counter.get() % 2 === 0,
 });
 
 // ... use it for a while ...
@@ -223,7 +223,7 @@ A stateful signal that holds a value and notifies listeners when it changes.
 
 #### Properties
 
-- **`.value: T`**
+- **`.get(): T`**
   Gets the current value of the signal.
 
 #### Methods
@@ -250,7 +250,7 @@ A read-only signal that derives its value from a set of dependency signals.
 
 #### Properties
 
-- **`.value: T`**
+- **`.get(): T`**
   Gets the current memoized value. The `get` function is only re-executed if a dependency has changed.
 
 ---
@@ -371,10 +371,10 @@ import {ComputedSignal} from '@alwatr/signal';
 const fullName = new ComputedSignal<string>({
   signalId: 'user-fullName',
   deps: [firstName], // این سیگنال محاسباتی به firstName وابسته است
-  get: () => `User: ${firstName.value}`,
+  get: () => `User: ${firstName.get()}`,
 });
 
-console.log(fullName.value); // خروجی: "User: John"
+console.log(fullName.get()); // خروجی: "User: John"
 ```
 
 ### ۴. ایجاد `EffectSignal`
@@ -387,7 +387,7 @@ import {EffectSignal} from '@alwatr/signal';
 const loggerEffect = new EffectSignal({
   deps: [fullName, counter], // این افکت به fullName و counter وابسته است
   run: () => {
-    console.log(`${fullName.value} has clicked ${counter.value} times.`);
+    console.log(`${fullName.get()} has clicked ${counter.get()} times.`);
   },
 });
 ```
@@ -436,7 +436,7 @@ User: Jane has clicked 1 times.
 // یک سیگنال محاسباتی ایجاد کنید
 const isEven = new ComputedSignal({
   deps: [counter],
-  get: () => counter.value % 2 === 0,
+  get: () => counter.get() % 2 === 0,
 });
 
 // ... مدتی از آن استفاده کنید ...
@@ -520,7 +520,7 @@ Alwatr Signal از یک مدل ناهمزمان قابل پیش‌بینی بر�
 
 #### خصوصیات
 
-- **`.value: T`**
+- **`.get(): T`**
   مقدار فعلی سیگنال را دریافت می‌کند.
 
 #### متدها
@@ -547,7 +547,7 @@ Alwatr Signal از یک مدل ناهمزمان قابل پیش‌بینی بر�
 
 #### خصوصیات
 
-- **`.value: T`**
+- **`.get(): T`**
   مقدار memoized شده فعلی را دریافت می‌کند. تابع `get` فقط در صورتی دوباره اجرا می‌شود که یکی از وابستگی‌ها تغییر کرده باشد.
 
 ---

--- a/packages/signal/README.md
+++ b/packages/signal/README.md
@@ -69,10 +69,10 @@ import {ComputedSignal} from '@alwatr/signal';
 const fullName = new ComputedSignal<string>({
   signalId: 'user-fullName',
   deps: [firstName], // This computed signal depends on firstName.
-  get: () => `User: ${firstName.value}`,
+  get: () => `User: ${firstName.get()}`,
 });
 
-console.log(fullName.value); // Outputs: "User: John"
+console.log(fullName.get()); // Outputs: "User: John"
 ```
 
 ### 4. Create an Effect Signal
@@ -85,7 +85,7 @@ import {EffectSignal} from '@alwatr/signal';
 const loggerEffect = new EffectSignal({
   deps: [fullName, counter], // This effect depends on fullName and counter.
   run: () => {
-    console.log(`${fullName.value} has clicked ${counter.value} times.`);
+    console.log(`${fullName.get()} has clicked ${counter.get()} times.`);
   },
 });
 ```
@@ -134,7 +134,7 @@ Signals that depend on other signals (like `ComputedSignal` and `EffectSignal`) 
 // Create a computed signal
 const isEven = new ComputedSignal({
   deps: [counter],
-  get: () => counter.value % 2 === 0,
+  get: () => counter.get() % 2 === 0,
 });
 
 // ... use it for a while ...
@@ -167,7 +167,7 @@ The `subscribe` method accepts an optional second argument to customize its beha
 - **`constructor(config)`**: Creates a new state signal.
   - `config.signalId`: `string`
   - `config.initialValue`: `T`
-- **`.value`**: `T` - Gets the current value.
+- **`.get()`**: `T` - Gets the current value.
 - **`.set(newValue: T)`**: Sets a new value and notifies listeners.
 
 ### `ComputedSignal<T>`
@@ -176,7 +176,7 @@ The `subscribe` method accepts an optional second argument to customize its beha
   - `config.signalId`: `string`
   - `config.deps`: `IReadonlySignal<unknown>[]` - Array of dependency signals.
   - `config.get`: `() => T` - The function to compute the value.
-- **`.value`**: `T` - Gets the current (memoized) value.
+- **`.get()`**: `T` - Gets the current (memoized) value.
 - **`.destroy()`**: Cleans up the signal's subscriptions. **(Important!)**
 
 ### `EffectSignal`
@@ -284,10 +284,10 @@ import {ComputedSignal} from '@alwatr/signal';
 const fullName = new ComputedSignal<string>({
   signalId: 'user-fullName',
   deps: [firstName], // این سیگنال محاسباتی به firstName وابسته است
-  get: () => `User: ${firstName.value}`,
+  get: () => `User: ${firstName.get()}`,
 });
 
-console.log(fullName.value); // خروجی: "User: John"
+console.log(fullName.get()); // خروجی: "User: John"
 ```
 
 ### ۴. ایجاد `EffectSignal`
@@ -300,7 +300,7 @@ import {EffectSignal} from '@alwatr/signal';
 const loggerEffect = new EffectSignal({
   deps: [fullName, counter], // این افکت به fullName و counter وابسته است
   run: () => {
-    console.log(`${fullName.value} has clicked ${counter.value} times.`);
+    console.log(`${fullName.get()} has clicked ${counter.get()} times.`);
   },
 });
 ```
@@ -349,7 +349,7 @@ User: Jane has clicked 1 times.
 // یک سیگنال محاسباتی ایجاد کنید
 const isEven = new ComputedSignal({
   deps: [counter],
-  get: () => counter.value % 2 === 0,
+  get: () => counter.get() % 2 === 0,
 });
 
 // ... مدتی از آن استفاده کنید ...
@@ -382,7 +382,7 @@ Alwatr Signal از یک مدل ناهمزمان قابل پیش‌بینی بر�
 - **`constructor(config)`**: یک سیگنال وضعیت جدید ایجاد می‌کند.
   - `config.signalId`: `string`
   - `config.initialValue`: `T`
-- **`.value`**: `T` - مقدار فعلی را دریافت می‌کند.
+- **`.get()`**: `T` - مقدار فعلی را دریافت می‌کند.
 - **`.set(newValue: T)`**: مقدار جدیدی را تنظیم کرده و شنوندگان را مطلع می‌کند.
 
 ### `ComputedSignal<T>`
@@ -391,7 +391,7 @@ Alwatr Signal از یک مدل ناهمزمان قابل پیش‌بینی بر�
   - `config.signalId`: `string`
   - `config.deps`: `IReadonlySignal<unknown>[]` - آرایه‌ای از سیگنال‌های وابسته.
   - `config.get`: `() => T` - تابعی برای محاسبه مقدار.
-- **`.value`**: `T` - مقدار فعلی (کش شده) را دریافت می‌کند.
+- **`.get()`**: `T` - مقدار فعلی (کش شده) را دریافت می‌کند.
 - **`.destroy()`**: اشتراک‌های سیگنال را پاک‌سازی می‌کند. **(مهم!)**
 
 ### `EffectSignal`

--- a/packages/signal/src/core/computed-signal.test.js
+++ b/packages/signal/src/core/computed-signal.test.js
@@ -17,7 +17,7 @@ describe('ComputedSignal', () => {
     signal = new ComputedSignal({
       signalId,
       deps: [dep1, dep2],
-      get: () => dep1.value + dep2.value,
+      get: () => dep1.get() + dep2.get(),
     });
   });
 
@@ -31,14 +31,14 @@ describe('ComputedSignal', () => {
     expect(ComputedSignal).toBeDefined();
     expect(signal).toBeInstanceOf(ComputedSignal);
     expect(signal.signalId).toBe(signalId);
-    expect(signal.value).toBe(3); // 1 + 2
+    expect(signal.get()).toBe(3); // 1 + 2
   });
 
   it('should compute value from dependencies', async () => {
-    expect(signal.value).toBe(3);
+    expect(signal.get()).toBe(3);
     dep1.set(5);
     await signal.untilNext();
-    expect(signal.value).toBe(7); // 5 + 2
+    expect(signal.get()).toBe(7); // 5 + 2
   });
 
   it('should notify subscribers when computed value changes', async () => {
@@ -115,7 +115,7 @@ describe('ComputedSignal', () => {
       deps: [],
       get: () => 42,
     });
-    expect(noDepSignal.value).toBe(42);
+    expect(noDepSignal.get()).toBe(42);
     noDepSignal.destroy();
   });
 
@@ -135,7 +135,7 @@ describe('ComputedSignal', () => {
   describe('destroyed signal', () => {
     it('should throw error when accessing value after destroy', () => {
       signal.destroy();
-      expect(() => signal.value).toThrow();
+      expect(() => signal.get()).toThrow();
     });
 
     it('should not notify after destroy', async () => {

--- a/packages/signal/src/core/computed-signal.ts
+++ b/packages/signal/src/core/computed-signal.ts
@@ -26,10 +26,10 @@ import type {ComputedSignalConfig, IReadonlySignal, SubscribeResult, SubscribeOp
  * const fullName = new ComputedSignal({
  *   signalId: 'fullName',
  *   deps: [firstName, lastName],
- *   get: () => `${firstName.value} ${lastName.value}`,
+ *   get: () => `${firstName.get()} ${lastName.get()}`,
  * });
  *
- * console.log(fullName.value); // Outputs: "John Doe"
+ * console.log(fullName.get()); // Outputs: "John Doe"
  *
  * // --- Subscribe to the computed value ---
  * fullName.subscribe(newFullName => {
@@ -38,7 +38,7 @@ import type {ComputedSignalConfig, IReadonlySignal, SubscribeResult, SubscribeOp
  *
  * // --- Update a dependency ---
  * lastName.set('Smith'); // Recalculates and logs: "Name changed to: John Smith"
- * console.log(fullName.value); // Outputs: "John Smith"
+ * console.log(fullName.get()); // Outputs: "John Smith"
  *
  * // --- IMPORTANT: Clean up when done ---
  * fullName.destroy();
@@ -57,7 +57,7 @@ export class ComputedSignal<T> implements IReadonlySignal<T> {
 
   /**
    * The internal `StateSignal` that holds the computed value.
-   * This is how the computed signal provides `.value` and `.subscribe()` methods.
+   * This is how the computed signal provides `.get()` and `.subscribe()` methods.
    * @protected
    */
   protected readonly internalSignal_ = new StateSignal<T>({
@@ -95,8 +95,8 @@ export class ComputedSignal<T> implements IReadonlySignal<T> {
    * @returns The current computed value.
    * @throws {Error} If accessed after the signal has been destroyed.
    */
-  public get value(): T {
-    return this.internalSignal_.value;
+  public get(): T {
+    return this.internalSignal_.get();
   }
 
   /**
@@ -136,7 +136,7 @@ export class ComputedSignal<T> implements IReadonlySignal<T> {
    * stopping future recalculations and allowing the signal to be garbage collected.
    * Failure to call `destroy()` will result in memory leaks.
    *
-   * After `destroy()` is called, any attempt to access `.value` or `.subscribe()` will throw an error.
+   * After `destroy()` is called, any attempt to access `.get()` or `.subscribe()` will throw an error.
    */
   public destroy(): void {
     this.logger_.logMethod?.('destroy');

--- a/packages/signal/src/core/effect-signal.ts
+++ b/packages/signal/src/core/effect-signal.ts
@@ -26,7 +26,7 @@ import type {EffectSignalConfig, IEffectSignal, SubscribeResult} from '../type.j
  *   signalId: 'analytics-effect',
  *   deps: [counter, user],
  *   run: () => {
- *     console.log(`Analytics: User '${user.value}' clicked ${counter.value} times.`);
+ *     console.log(`Analytics: User '${user.get()}' clicked ${counter.get()} times.`);
  *   },
  *   runImmediately: true, // Optional: run once on creation
  * });
@@ -84,18 +84,18 @@ export class EffectSignal implements IEffectSignal {
 
   public constructor(protected config_: EffectSignalConfig) {
     this.logger_.logMethod?.('constructor');
-    this.run_ = this.run_.bind(this);
+    this.scheduleExecution_ = this.scheduleExecution_.bind(this);
 
     // Subscribe to all dependencies. We don't need the previous value,
     // as the `runImmediately` option controls the initial execution.
     for (const signal of config_.deps) {
-      this.dependencySubscriptions__.push(signal.subscribe(this.run_, {receivePrevious: false}));
+      this.dependencySubscriptions__.push(signal.subscribe(this.scheduleExecution_, {receivePrevious: false}));
     }
 
     // Run the effect immediately if requested.
     if (config_.runImmediately === true) {
       // We don't need to await this, let it run in the background.
-      void this.run_();
+      void this.scheduleExecution_();
     }
   }
 
@@ -107,16 +107,16 @@ export class EffectSignal implements IEffectSignal {
    * dependencies change simultaneously.
    * @protected
    */
-  protected async run_(): Promise<void> {
-    this.logger_.logMethod?.('run_');
+  protected async scheduleExecution_(): Promise<void> {
+    this.logger_.logMethod?.('scheduleExecution_');
 
     if (this.isDestroyed__) {
-      this.logger_.incident?.('run_', 'run_on_destroyed_signal');
+      this.logger_.incident?.('scheduleExecution_', 'schedule_execution_on_destroyed_signal');
       return;
     }
     if (this.isRunning__) {
       // If an execution is already scheduled, do nothing.
-      this.logger_.logStep?.('run_', 'skipped_because_already_running');
+      this.logger_.logStep?.('scheduleExecution_', 'skipped_because_already_running');
       return;
     }
 
@@ -126,16 +126,16 @@ export class EffectSignal implements IEffectSignal {
       // Wait for the next macrotask to batch simultaneous updates.
       await delay.nextMacrotask();
       if (this.isDestroyed__) {
-        this.logger_.incident?.('run_', 'destroyed_during_delay');
+        this.logger_.incident?.('scheduleExecution_', 'destroyed_during_delay');
         this.isRunning__ = false;
         return;
       }
 
-      this.logger_.logStep?.('run_', 'executing_effect');
+      this.logger_.logStep?.('scheduleExecution_', 'executing_effect');
       await this.config_.run();
     }
     catch (err) {
-      this.logger_.error('run_', 'effect_failed', err);
+      this.logger_.error('scheduleExecution_', 'effect_failed', err);
     }
 
     // Reset the flag after the current execution is complete.

--- a/packages/signal/src/core/state-signal.test.js
+++ b/packages/signal/src/core/state-signal.test.js
@@ -19,7 +19,7 @@ describe('StateSignal', () => {
     expect(StateSignal).toBeDefined();
     expect(signal).toBeInstanceOf(StateSignal);
     expect(signal.signalId).toBe(signalId);
-    expect(signal.value).toBe(0);
+    expect(signal.get()).toBe(0);
   });
 
   it('should notify subscribers when value changes', async () => {
@@ -218,7 +218,7 @@ describe('StateSignal', () => {
     });
 
     it('should throw an error when accessing value on a destroyed signal', () => {
-      expect(() => signal.value).toThrow(`Cannot interact with a destroyed signal (id: ${signalId})`);
+      expect(() => signal.get()).toThrow(`Cannot interact with a destroyed signal (id: ${signalId})`);
     });
 
     it('should not notify any listeners after being destroyed', async () => {

--- a/packages/signal/src/core/state-signal.ts
+++ b/packages/signal/src/core/state-signal.ts
@@ -22,7 +22,7 @@ import type {StateSignalConfig, ListenerCallback, SubscribeOptions, SubscribeRes
  * });
  *
  * // Get the current value.
- * console.log(counter.value); // Outputs: 0
+ * console.log(counter.get()); // Outputs: 0
  *
  * // Subscribe to changes.
  * const subscription = counter.subscribe(newValue => {
@@ -63,9 +63,9 @@ export class StateSignal<T> extends SignalBase<T> implements IReadonlySignal<T> 
    * @returns The current value.
    *
    * @example
-   * console.log(mySignal.value);
+   * console.log(mySignal.get());
    */
-  public get value(): T {
+  public get(): T {
     this.checkDestroyed_();
     return this.value__;
   }
@@ -83,7 +83,7 @@ export class StateSignal<T> extends SignalBase<T> implements IReadonlySignal<T> 
    * mySignal.set(42);
    *
    * // For object types, it's best practice to set an immutable new object.
-   * mySignal.set({ ...mySignal.value, property: 'new-value' });
+   * mySignal.set({ ...mySignal.get(), property: 'new-value' });
    */
   public set(newValue: T): void {
     this.logger_.logMethodArgs?.('set', {newValue});

--- a/packages/signal/src/creators/computed.ts
+++ b/packages/signal/src/creators/computed.ts
@@ -24,10 +24,10 @@ import type {ComputedSignalConfig} from '../type.js';
  * const fullName = createComputedSignal({
  *   signalId: 'fullName',
  *   deps: [firstName, lastName],
- *   get: () => `${firstName.value} ${lastName.value}`,
+ *   get: () => `${firstName.get()} ${lastName.get()}`,
  * });
  *
- * console.log(fullName.value); // "John Doe"
+ * console.log(fullName.get()); // "John Doe"
  *
  * // IMPORTANT: Always destroy a computed signal when no longer needed.
  * // fullName.destroy();

--- a/packages/signal/src/creators/effect.ts
+++ b/packages/signal/src/creators/effect.ts
@@ -25,7 +25,7 @@ import type {EffectSignalConfig} from '../type.js';
  * const analyticsEffect = createEffect({
  *   deps: [counter, user],
  *   run: () => {
- *     console.log(`Analytics: User '${user.value}' clicked ${counter.value} times.`);
+ *     console.log(`Analytics: User '${user.get()}' clicked ${counter.get()} times.`);
  *   },
  *   runImmediately: true, // Optional: run once on creation
  * });

--- a/packages/signal/src/creators/state.ts
+++ b/packages/signal/src/creators/state.ts
@@ -19,9 +19,9 @@ import type {StateSignalConfig} from '../type.js';
  *   initialValue: 0,
  * });
  *
- * console.log(counter.value); // Outputs: 0
+ * console.log(counter.get()); // Outputs: 0
  * counter.set(1);
- * console.log(counter.value); // Outputs: 1
+ * console.log(counter.get()); // Outputs: 1
  */
 export function createStateSignal<T>(config: StateSignalConfig<T>): StateSignal<T> {
   return new StateSignal(config);

--- a/packages/signal/src/operators/debounce.ts
+++ b/packages/signal/src/operators/debounce.ts
@@ -44,8 +44,8 @@ import type {IReadonlySignal, DebounceSignalConfig} from '../type.js';
  * createEffect({
  *   deps: [debouncedSearch],
  *   run: () => {
- *     if (debouncedSearch.value) {
- *       console.log(`🚀 Sending API request for: "${debouncedSearch.value}"`);
+ *     if (debouncedSearch.get()) {
+ *       console.log(`🚀 Sending API request for: "${debouncedSearch.get()}"`);
  *     }
  *   },
  * });
@@ -64,7 +64,7 @@ export function createDebouncedSignal<T>(sourceSignal: IReadonlySignal<T>, confi
 
   const internalSignal = new StateSignal<T>({
     signalId: `${signalId}-internal`,
-    initialValue: sourceSignal.value,
+    initialValue: sourceSignal.get(),
   });
 
   const debouncer = createDebouncer({
@@ -79,7 +79,7 @@ export function createDebouncedSignal<T>(sourceSignal: IReadonlySignal<T>, confi
   return createComputedSignal({
     signalId,
     deps: [internalSignal],
-    get: () => internalSignal.value,
+    get: () => internalSignal.get(),
     onDestroy: () => {
       if (internalSignal.isDestroyed) return;
       subscription.unsubscribe();

--- a/packages/signal/src/operators/filter.ts
+++ b/packages/signal/src/operators/filter.ts
@@ -36,8 +36,8 @@ import type {IReadonlySignal} from '../type.js';
  * run: () => {
  * // This effect only runs for even numbers.
  * // The value can be `undefined` on the first run if initialValue is not even.
- * if (evenNumberSignal.value !== undefined) {
- * console.log(`Even number detected: ${evenNumberSignal.value}`);
+ * if (evenNumberSignal.get() !== undefined) {
+ * console.log(`Even number detected: ${evenNumberSignal.get()}`);
  * }
  * },
  * runImmediately: true,
@@ -52,7 +52,7 @@ export function createFilteredSignal<T>(
   predicate: (value: T) => boolean,
   signalId = `${sourceSignal.signalId}-filtered`,
 ): ComputedSignal<T | undefined> {
-  const initialValue = predicate(sourceSignal.value) ? sourceSignal.value : undefined;
+  const initialValue = predicate(sourceSignal.get()) ? sourceSignal.get() : undefined;
 
   const internalSignal = createStateSignal({
     signalId: `${signalId}-internal`,
@@ -68,7 +68,7 @@ export function createFilteredSignal<T>(
   return createComputedSignal({
     signalId,
     deps: [internalSignal],
-    get: () => internalSignal.value,
+    get: () => internalSignal.get(),
     onDestroy: () => {
       subscription.unsubscribe();
       internalSignal.destroy();

--- a/packages/signal/src/operators/filter.ts
+++ b/packages/signal/src/operators/filter.ts
@@ -52,7 +52,8 @@ export function createFilteredSignal<T>(
   predicate: (value: T) => boolean,
   signalId = `${sourceSignal.signalId}-filtered`,
 ): ComputedSignal<T | undefined> {
-  const initialValue = predicate(sourceSignal.get()) ? sourceSignal.get() : undefined;
+  const sourceValue = sourceSignal.get();
+  const initialValue = predicate(sourceValue) ? sourceValue : undefined;
 
   const internalSignal = createStateSignal({
     signalId: `${signalId}-internal`,

--- a/packages/signal/src/operators/map.ts
+++ b/packages/signal/src/operators/map.ts
@@ -30,10 +30,10 @@ import type {IReadonlySignal} from '../type.js';
  *   (user) => user.name,
  * );
  *
- * console.log(userNameSignal.value); // Outputs: "John"
+ * console.log(userNameSignal.get()); // Outputs: "John"
  * // in next macro-task ...
  * userSignal.set({ name: 'Jane', age: 32 });
- * console.log(userNameSignal.value); // Outputs: "Jane"
+ * console.log(userNameSignal.get()); // Outputs: "Jane"
  */
 export function createMappedSignal<T, R>(
   sourceSignal: IReadonlySignal<T>,
@@ -43,6 +43,6 @@ export function createMappedSignal<T, R>(
   return createComputedSignal({
     signalId,
     deps: [sourceSignal],
-    get: () => projectFunction(sourceSignal.value),
+    get: () => projectFunction(sourceSignal.get()),
   });
 }

--- a/packages/signal/src/type.ts
+++ b/packages/signal/src/type.ts
@@ -139,7 +139,7 @@ export interface IReadonlySignal<T> {
   /**
    * The current value of the signal.
    */
-  readonly value: T;
+  get: () => T;
 
   /**
    * Indicates whether the signal has been destroyed.
@@ -209,7 +209,7 @@ export interface ComputedSignalConfig<T> extends SignalConfig {
    * const counter = new StateSignal({initialValue: 0});
    * const isEven = new ComputedSignal({
    *   deps: [counter],
-   *   get: () => counter.value % 2 === 0,
+   *   get: () => counter.get() % 2 === 0,
    * });
    */
   get: () => T;
@@ -245,7 +245,7 @@ export interface EffectSignalConfig {
    * const counter = new StateSignal({initialValue: 0});
    * new EffectSignal({
    *   deps: [counter],
-   *   run: () => console.log(`The counter is now: ${counter.value}`),
+   *   run: () => console.log(`The counter is now: ${counter.get()}`),
    * });
    */
   run: () => Awaitable<void>;


### PR DESCRIPTION
Change `signal.value` to `signal.get()` across the codebase and rename the `run_` method to `scheduleExecution_` in `EffectSignal` for improved clarity.