### PR TITLE
feat: Integrate localStorage support with PersistentStateSignal

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@alwatr/eslint-config": "^5.6.2",
     "@alwatr/prettier-config": "^5.0.4",
     "@alwatr/tsconfig-base": "^6.0.2",
-    "@alwatr/yarn-upgrade": "^1.0.11",
+    "@alwatr/yarn-upgrade": "^1.0.12",
     "@lerna-lite/changed": "^4.8.0",
     "@lerna-lite/cli": "^4.8.0",
     "@lerna-lite/diff": "^4.8.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@alwatr/eslint-config": "^5.6.2",
     "@alwatr/prettier-config": "^5.0.4",
     "@alwatr/tsconfig-base": "^6.0.2",
-    "@alwatr/yarn-upgrade": "^1.0.10",
+    "@alwatr/yarn-upgrade": "^1.0.11",
     "@lerna-lite/changed": "^4.8.0",
     "@lerna-lite/cli": "^4.8.0",
     "@lerna-lite/diff": "^4.8.0",

--- a/packages/flux/package.json
+++ b/packages/flux/package.json
@@ -9,10 +9,10 @@
     "@alwatr/signal": "workspace:*"
   },
   "devDependencies": {
-    "@alwatr/nano-build": "^6.3.1",
+    "@alwatr/nano-build": "^6.3.2",
     "@alwatr/prettier-config": "^5.0.4",
     "@alwatr/tsconfig-base": "^6.0.2",
-    "@alwatr/type-helper": "^6.1.1",
+    "@alwatr/type-helper": "^6.1.2",
     "@types/node": "^22.18.6",
     "jest": "^30.1.3",
     "typescript": "^5.9.2"

--- a/packages/fsm/package.json
+++ b/packages/fsm/package.json
@@ -5,7 +5,7 @@
   "author": "S. Ali Mihandoost <ali.mihandoost@gmail.com> (https://ali.mihandoost.com)",
   "bugs": "https://github.com/Alwatr/flux/issues",
   "dependencies": {
-    "@alwatr/logger": "^6.0.6",
+    "@alwatr/logger": "^6.0.7",
     "@alwatr/signal": "workspace:*"
   },
   "devDependencies": {

--- a/packages/fsm/package.json
+++ b/packages/fsm/package.json
@@ -5,14 +5,14 @@
   "author": "S. Ali Mihandoost <ali.mihandoost@gmail.com> (https://ali.mihandoost.com)",
   "bugs": "https://github.com/Alwatr/flux/issues",
   "dependencies": {
-    "@alwatr/logger": "^6.0.5",
+    "@alwatr/logger": "^6.0.6",
     "@alwatr/signal": "workspace:*"
   },
   "devDependencies": {
-    "@alwatr/nano-build": "^6.3.1",
+    "@alwatr/nano-build": "^6.3.2",
     "@alwatr/prettier-config": "^5.0.4",
     "@alwatr/tsconfig-base": "^6.0.2",
-    "@alwatr/type-helper": "^6.1.1",
+    "@alwatr/type-helper": "^6.1.2",
     "@types/node": "^22.18.6",
     "jest": "^30.1.3",
     "typescript": "^5.9.2"

--- a/packages/fsm/src/facade.ts
+++ b/packages/fsm/src/facade.ts
@@ -1,6 +1,8 @@
+import {createPersistentStateSignal, createStateSignal} from '@alwatr/signal';
+
 import {FsmService} from './fsm-service.js';
 
-import type {MachineEvent, StateMachineConfig} from './type.js';
+import type {MachineEvent, MachineState, StateMachineConfig} from './type.js';
 
 /**
  * A simple and clean factory function for creating an `FsmService` instance.
@@ -62,8 +64,25 @@ import type {MachineEvent, StateMachineConfig} from './type.js';
  * // lightService.destroy();
  * ```
  */
-export function createFsmService<TState extends string, TEvent extends MachineEvent, TContext extends Record<string, unknown>>(
+export function createFsmService<TState extends string, TEvent extends MachineEvent, TContext extends JsonObject>(
   config: StateMachineConfig<TState, TEvent, TContext>,
 ): FsmService<TState, TEvent, TContext> {
-  return new FsmService(config);
+  const initialValue: MachineState<TState, TContext> = {
+    name: config.initial,
+    context: config.context,
+  };
+
+  const stateSignal = config.persistent
+    ? createPersistentStateSignal<MachineState<TState, TContext>>({
+      name: `fsm-state-${config.name}`,
+      // storageKey: config.persistent.storageKey ?? config.name,
+      defaultValue: initialValue,
+      schemaVersion: config.persistent.schemaVersion,
+    })
+    : createStateSignal<MachineState<TState, TContext>>({
+      name: `fsm-state-${config.name}`,
+      initialValue: initialValue,
+    });
+
+  return new FsmService(config, stateSignal);
 }

--- a/packages/fsm/src/facade.ts
+++ b/packages/fsm/src/facade.ts
@@ -75,7 +75,7 @@ export function createFsmService<TState extends string, TEvent extends MachineEv
   const stateSignal = config.persistent
     ? createPersistentStateSignal<MachineState<TState, TContext>>({
       name: `fsm-state-${config.name}`,
-      // storageKey: config.persistent.storageKey ?? config.name,
+      storageKey: config.persistent.storageKey ?? config.name,
       defaultValue: initialValue,
       schemaVersion: config.persistent.schemaVersion,
     })

--- a/packages/fsm/src/fsm-service.ts
+++ b/packages/fsm/src/fsm-service.ts
@@ -1,5 +1,5 @@
 import {createLogger} from '@alwatr/logger';
-import {createStateSignal, createEventSignal} from '@alwatr/signal';
+import {createEventSignal, type StateSignal, type PersistentStateSignal} from '@alwatr/signal';
 
 import type {StateMachineConfig, MachineState, MachineEvent, Transition, Effect, Assigner} from './type.js';
 
@@ -12,7 +12,7 @@ import type {StateMachineConfig, MachineState, MachineEvent, Transition, Effect,
  * @template TEvent The union type of all possible events.
  * @template TContext The type of the machine's context (extended state).
  */
-export class FsmService<TState extends string, TEvent extends MachineEvent, TContext extends Record<string, unknown>> {
+export class FsmService<TState extends string, TEvent extends MachineEvent, TContext extends JsonObject> {
   protected readonly logger_ = createLogger(`fsm:${this.config_.name}`);
 
   /** The event signal for sending events to the FSM. */
@@ -20,18 +20,13 @@ export class FsmService<TState extends string, TEvent extends MachineEvent, TCon
     name: `fsm-event-${this.config_.name}`,
   });
 
-  private readonly stateSignal__ = createStateSignal<MachineState<TState, TContext>>({
-    name: `fsm-state-${this.config_.name}`,
-    initialValue: {
-      name: this.config_.initial,
-      context: this.config_.context,
-    },
-  });
-
   /** The public, read-only state signal. Subscribe to react to state changes. */
   public readonly stateSignal = this.stateSignal__.asReadonly();
 
-  constructor(protected readonly config_: StateMachineConfig<TState, TEvent, TContext>) {
+  constructor(
+    protected readonly config_: StateMachineConfig<TState, TEvent, TContext>,
+    private readonly stateSignal__: StateSignal<MachineState<TState, TContext>> | PersistentStateSignal<MachineState<TState, TContext>>,
+  ) {
     this.logger_.logMethodArgs?.('constructor', config_);
     this.eventSignal.subscribe(this.processTransition__.bind(this), {receivePrevious: false});
   }

--- a/packages/fsm/src/type.ts
+++ b/packages/fsm/src/type.ts
@@ -8,12 +8,12 @@ import type {} from '@alwatr/type-helper';
  * @template TState The union type of the finite state values.
  * @template TContext The type of the context object (extended state).
  */
-export interface MachineState<TState extends string, TContext extends Record<string, unknown>> {
+export type MachineState<TState extends string, TContext extends JsonObject> = {
   /** The current finite state value. */
   readonly name: TState;
   /** The context (extended state) of the machine, holding quantitative data. */
   readonly context: TContext;
-}
+};
 
 /**
  * Represents an event that can be sent to the state machine.
@@ -36,7 +36,7 @@ export interface MachineEvent<TEventType extends string = string> {
  * @template TEvent The type of the event that triggered this assigner.
  * @returns A partial context object to be merged into the machine's context.
  */
-export type Assigner<TEvent extends MachineEvent, TContext extends Record<string, unknown>> = (
+export type Assigner<TEvent extends MachineEvent, TContext extends JsonObject> = (
   event: Readonly<TEvent>,
   context: Readonly<TContext>,
   // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
@@ -50,10 +50,10 @@ export type Assigner<TEvent extends MachineEvent, TContext extends Record<string
  * @template TEvent The type of the event that triggered this effect.
  * @returns void or a Promise<void>.
  */
-export type Effect<TEvent extends MachineEvent, TContext extends Record<string, unknown>> = (
+export type Effect<TEvent extends MachineEvent, TContext extends JsonObject> = (
   event: Readonly<TEvent>,
   context: Readonly<TContext>,
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 ) => Awaitable<TEvent | void>;
 
 /**
@@ -64,7 +64,7 @@ export type Effect<TEvent extends MachineEvent, TContext extends Record<string, 
  * @template TEvent The type of the event.
  * @returns `true` if the transition should be taken, `false` otherwise.
  */
-export type Condition<TEvent extends MachineEvent, TContext extends Record<string, unknown>> = (
+export type Condition<TEvent extends MachineEvent, TContext extends JsonObject> = (
   event: Readonly<TEvent>,
   context: Readonly<TContext>,
 ) => boolean;
@@ -77,13 +77,31 @@ export type Condition<TEvent extends MachineEvent, TContext extends Record<strin
  * @template TEvent The type of the event.
  * @template TContext The type of the machine's context.
  */
-export interface Transition<TState extends string, TEvent extends MachineEvent, TContext extends Record<string, unknown>> {
+export interface Transition<TState extends string, TEvent extends MachineEvent, TContext extends JsonObject> {
   /** The target state to transition to. If undefined, it's an internal transition. */
   readonly target?: TState;
   /** A condition function that must return true for the transition to occur. */
   readonly condition?: Condition<TEvent, TContext>;
   /** An array of assigners to execute. These update context synchronously. */
   readonly assigners?: SingleOrArray<Assigner<TEvent, TContext>>;
+}
+
+/**
+ * Configuration options for persisting the FSM state in localStorage.
+ */
+export interface FsmPersistenceConfig {
+  /**
+   * The version of the state's data structure (schema).
+   * Increment this number whenever you make a breaking change to the state's context shape.
+   */
+  schemaVersion: number;
+
+  /**
+   * The key under which to store the FSM state in localStorage.
+   *
+   * @default ‍`signal-name`
+   */
+  storageKey?: string;
 }
 
 /**
@@ -94,12 +112,17 @@ export interface Transition<TState extends string, TEvent extends MachineEvent, 
  * @template TEvent The union type of all possible events.
  * @template TContext The type of the context object.
  */
-export interface StateMachineConfig<TState extends string, TEvent extends MachineEvent, TContext extends Record<string, unknown>>
+export interface StateMachineConfig<TState extends string, TEvent extends MachineEvent, TContext extends JsonObject>
   extends Pick<SignalConfig, 'name'> {
   /** The initial finite state value. */
   readonly initial: TState;
+
   /** The initial context (extended state) of the machine. */
   readonly context: TContext;
+
+  /** If provided, the FSM's state will be persisted in localStorage. */
+  persistent?: FsmPersistenceConfig;
+
   /** An object defining all possible states and their transitions. */
   readonly states: {
     readonly [S in TState]?: {

--- a/packages/fsm/src/type.ts
+++ b/packages/fsm/src/type.ts
@@ -98,7 +98,7 @@ export interface FsmPersistenceConfig {
 
   /**
    * The key under which to store the FSM state in localStorage.
-   * @default ‍`signal-name`
+   * @default `signal-name`
    */
   storageKey?: string;
 }

--- a/packages/fsm/src/type.ts
+++ b/packages/fsm/src/type.ts
@@ -98,7 +98,6 @@ export interface FsmPersistenceConfig {
 
   /**
    * The key under which to store the FSM state in localStorage.
-   *
    * @default ‍`signal-name`
    */
   storageKey?: string;

--- a/packages/signal/package.json
+++ b/packages/signal/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@alwatr/debounce": "^1.1.6",
     "@alwatr/delay": "^6.0.8",
+    "@alwatr/local-storage": "^6.1.8",
     "@alwatr/logger": "^6.0.5"
   },
   "devDependencies": {

--- a/packages/signal/package.json
+++ b/packages/signal/package.json
@@ -5,16 +5,16 @@
   "author": "S. Ali Mihandoost <ali.mihandoost@gmail.com>",
   "bugs": "https://github.com/Alwatr/flux/issues",
   "dependencies": {
-    "@alwatr/debounce": "^1.1.6",
-    "@alwatr/delay": "^6.0.8",
-    "@alwatr/local-storage": "^6.1.8",
-    "@alwatr/logger": "^6.0.5"
+    "@alwatr/debounce": "^1.1.7",
+    "@alwatr/delay": "^6.0.9",
+    "@alwatr/local-storage": "^6.2.0",
+    "@alwatr/logger": "^6.0.6"
   },
   "devDependencies": {
-    "@alwatr/nano-build": "^6.3.1",
+    "@alwatr/nano-build": "^6.3.2",
     "@alwatr/prettier-config": "^5.0.4",
     "@alwatr/tsconfig-base": "^6.0.2",
-    "@alwatr/type-helper": "^6.1.1",
+    "@alwatr/type-helper": "^6.1.2",
     "@jest/globals": "^30.1.2",
     "@types/node": "^22.18.6",
     "jest": "^30.1.3",

--- a/packages/signal/package.json
+++ b/packages/signal/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@alwatr/debounce": "^1.1.7",
     "@alwatr/delay": "^6.0.9",
-    "@alwatr/local-storage": "^6.2.0",
+    "@alwatr/local-storage": "^6.3.0",
     "@alwatr/logger": "^6.0.6"
   },
   "devDependencies": {

--- a/packages/signal/package.json
+++ b/packages/signal/package.json
@@ -5,10 +5,10 @@
   "author": "S. Ali Mihandoost <ali.mihandoost@gmail.com>",
   "bugs": "https://github.com/Alwatr/flux/issues",
   "dependencies": {
-    "@alwatr/debounce": "^1.1.7",
-    "@alwatr/delay": "^6.0.9",
-    "@alwatr/local-storage": "^6.3.0",
-    "@alwatr/logger": "^6.0.6"
+    "@alwatr/debounce": "^1.1.8",
+    "@alwatr/delay": "^6.0.10",
+    "@alwatr/local-storage": "^6.3.3",
+    "@alwatr/logger": "^6.0.7"
   },
   "devDependencies": {
     "@alwatr/nano-build": "^6.3.2",

--- a/packages/signal/src/core/persistent-state-signal.ts
+++ b/packages/signal/src/core/persistent-state-signal.ts
@@ -1,0 +1,84 @@
+import {createLocalStorageProvider} from '@alwatr/local-storage';
+
+import {StateSignal} from './state-signal.js';
+
+import type {PersistentStateSignalConfig} from '../type.js';
+import type {LocalStorageProvider} from '@alwatr/local-storage';
+
+/**
+ * A stateful signal that persists its value in the browser's localStorage.
+ *
+ * It extends the functionality of a standard `StateSignal` by automatically reading
+ * its initial value from localStorage and writing back any subsequent changes.
+ *
+ * @template T The type of the state it holds.
+ */
+export class PersistentStateSignal<T extends JsonValue> extends StateSignal<T> {
+  /**
+   * The underlying storage provider instance.
+   * @private
+   */
+  private readonly storageProvider__: LocalStorageProvider<T>;
+
+  /**
+   * The subscription to the signal's own changes to sync with storage.
+   * We subscribe to our own signal. When the value is set from anywhere,
+   * this listener will trigger and write it to localStorage.
+   * @private
+   */
+  private readonly storageSyncSubscription__ = this.subscribe(
+    (newValue) => {
+      this.logger_.logMethodArgs?.('storage_sync', {newValue});
+      this.storageProvider__.write(newValue);
+    },
+    {receivePrevious: false}, // Only listen for *new* changes.
+  );
+
+  constructor(config: PersistentStateSignalConfig<T>) {
+    // 1. Create the LocalStorageProvider instance.
+    const storageProvider = createLocalStorageProvider<T>({
+      name: config.name,
+      schemaVersion: config.schemaVersion,
+      defaultValue: config.defaultValue,
+    });
+
+    // 2. Read the initial value from storage.
+    // The .read() method guarantees a valid value is returned (either from storage or the default).
+    const initialValue = storageProvider.read();
+
+    // 3. Call the parent constructor with the correct initial value.
+    super({
+      name: config.name,
+      initialValue,
+      onDestroy: config.onDestroy,
+    });
+
+    this.storageProvider__ = storageProvider;
+    this.logger_.logMethodArgs?.('constructor', {
+      name: config.name,
+      schemaVersion: config.schemaVersion,
+      initialValue,
+    });
+  }
+
+  /**
+   * Removes the value from localStorage.
+   * This provides a clean way to clear persisted data.
+   */
+  public remove(): void {
+    this.checkDestroyed_();
+    this.logger_.logMethod?.('remove');
+    // Remove from storage.
+    this.storageProvider__.remove();
+  }
+
+  /**
+   * Overrides the destroy method to also clean up the storage sync subscription.
+   */
+  public override destroy(): void {
+    this.logger_.logMethod?.('destroy');
+    // Unsubscribe from the sync listener to prevent memory leaks.
+    this.storageSyncSubscription__.unsubscribe();
+    super.destroy();
+  }
+}

--- a/packages/signal/src/core/persistent-state-signal.ts
+++ b/packages/signal/src/core/persistent-state-signal.ts
@@ -25,7 +25,7 @@ export class PersistentStateSignal<T extends JsonValue> extends StateSignal<Json
    * Debouncer to limit how often we write to localStorage.
    * @private
    */
-  private storageDebouncer__;
+  private readonly storageDebouncer__;
 
   /**
    * The subscription to the signal's own changes to sync with storage.
@@ -77,7 +77,7 @@ export class PersistentStateSignal<T extends JsonValue> extends StateSignal<Json
    * Syncs the new value to storage.
    * @param newValue The new value to sync to storage.
    */
-  private syncStorage__(newValue: Jsonify<T> | T): void {
+  private syncStorage__(newValue: Jsonify<T>): void {
     this.logger_.logMethodArgs?.('syncStorage__', newValue);
     this.storageProvider__.write(newValue);
   }

--- a/packages/signal/src/core/persistent-state-signal.ts
+++ b/packages/signal/src/core/persistent-state-signal.ts
@@ -69,10 +69,30 @@ export class PersistentStateSignal<T extends JsonValue> extends StateSignal<Json
    * signal's internal state.
    *
    * @param newValue The new rich value to set.
+   * @param convertDataType If true, converts `newValue` from `T` to `Jsonify<T>`.
+   *                        Default is false, meaning `newValue` is already `Jsonify<T>`.
    */
-  public override set(newValue: T | Jsonify<T>): void {
-    const serializedValue = this.storageProvider__.convertDataType(newValue);
-    super.set(serializedValue);
+  public override set(newValue: Jsonify<T>): void;
+  
+  /**
+   * Updates the signal's value.
+   *
+   * This method accepts the rich type `T` for developer convenience,
+   * immediately serializes it to `Jsonify<T>`, and then updates the
+   * signal's internal state.
+   *
+   * @param newValue The new rich value to set.
+   * @param convertDataType If true, converts `newValue` from `T` to `Jsonify<T>`.
+   *                        Default is false, meaning `newValue` is already `Jsonify<T>`.
+   */
+  public override set(newValue: T | Jsonify<T>, convertDataType: true): void;
+  public override set(newValue: T | Jsonify<T>, convertDataType?: true): void {
+    if (convertDataType === true) {
+      super.set(this.storageProvider__.convertDataType(newValue as T));
+    }
+    else {
+      super.set(newValue as Jsonify<T>);
+    }
   }
 
   /**

--- a/packages/signal/src/core/persistent-state-signal.ts
+++ b/packages/signal/src/core/persistent-state-signal.ts
@@ -1,3 +1,4 @@
+import {createDebouncer} from '@alwatr/debounce';
 import {createLocalStorageProvider} from '@alwatr/local-storage';
 
 import {StateSignal} from './state-signal.js';
@@ -21,18 +22,18 @@ export class PersistentStateSignal<T extends JsonValue> extends StateSignal<Json
   private readonly storageProvider__: LocalStorageProvider<T>;
 
   /**
+   * Debouncer to limit how often we write to localStorage.
+   * @private
+   */
+  private storageDebouncer__;
+
+  /**
    * The subscription to the signal's own changes to sync with storage.
    * We subscribe to our own signal. When the value is set from anywhere,
    * this listener will trigger and write it to localStorage.
    * @private
    */
-  private readonly storageSyncSubscription__ = this.subscribe(
-    (newValue) => {
-      this.logger_.logMethodArgs?.('storage_sync', newValue);
-      this.storageProvider__.write(newValue);
-    },
-    {receivePrevious: false}, // Only listen for *new* changes.
-  );
+  private readonly storageSyncSubscription__;
 
   constructor(config: PersistentStateSignalConfig<T>) {
     // 1. Create the LocalStorageProvider instance.
@@ -53,12 +54,32 @@ export class PersistentStateSignal<T extends JsonValue> extends StateSignal<Json
       onDestroy: config.onDestroy,
     });
 
-    this.storageProvider__ = storageProvider;
     this.logger_.logMethodArgs?.('constructor', {
       name: config.name,
       schemaVersion: config.schemaVersion,
       initialValue,
     });
+
+    this.storageProvider__ = storageProvider;
+
+    this.storageDebouncer__ = createDebouncer({
+      delay: config.saveDebounceDelay ?? 500,
+      leading: false,
+      trailing: true,
+      thisContext: this,
+      func: this.syncStorage__,
+    });
+
+    this.storageSyncSubscription__ = this.subscribe(this.storageDebouncer__.trigger, {receivePrevious: false});
+  }
+
+  /**
+   * Syncs the new value to storage.
+   * @param newValue The new value to sync to storage.
+   */
+  private syncStorage__(newValue: Jsonify<T> | T): void {
+    this.logger_.logMethodArgs?.('syncStorage__', newValue);
+    this.storageProvider__.write(newValue);
   }
 
   /**
@@ -73,7 +94,7 @@ export class PersistentStateSignal<T extends JsonValue> extends StateSignal<Json
    *                        Default is false, meaning `newValue` is already `Jsonify<T>`.
    */
   public override set(newValue: Jsonify<T>): void;
-  
+
   /**
    * Updates the signal's value.
    *
@@ -111,6 +132,8 @@ export class PersistentStateSignal<T extends JsonValue> extends StateSignal<Json
    */
   public override destroy(): void {
     this.logger_.logMethod?.('destroy');
+    // Flush any pending storage writes before destroying.
+    this.storageDebouncer__.flush();
     // Unsubscribe from the sync listener to prevent memory leaks.
     this.storageSyncSubscription__.unsubscribe();
     super.destroy();

--- a/packages/signal/src/core/persistent-state-signal.ts
+++ b/packages/signal/src/core/persistent-state-signal.ts
@@ -14,7 +14,7 @@ import type {LocalStorageProvider} from '@alwatr/local-storage';
  *
  * @template T The type of the state it holds.
  */
-export class PersistentStateSignal<T extends JsonValue> extends StateSignal<Jsonify<T>> {
+export class PersistentStateSignal<T> extends StateSignal<Jsonify<T>> {
   /**
    * The underlying storage provider instance.
    * @private

--- a/packages/signal/src/core/persistent-state-signal.ts
+++ b/packages/signal/src/core/persistent-state-signal.ts
@@ -13,7 +13,7 @@ import type {LocalStorageProvider} from '@alwatr/local-storage';
  *
  * @template T The type of the state it holds.
  */
-export class PersistentStateSignal<T extends JsonValue> extends StateSignal<T> {
+export class PersistentStateSignal<T extends JsonValue> extends StateSignal<Jsonify<T>> {
   /**
    * The underlying storage provider instance.
    * @private
@@ -28,7 +28,7 @@ export class PersistentStateSignal<T extends JsonValue> extends StateSignal<T> {
    */
   private readonly storageSyncSubscription__ = this.subscribe(
     (newValue) => {
-      this.logger_.logMethodArgs?.('storage_sync', {newValue});
+      this.logger_.logMethodArgs?.('storage_sync', newValue);
       this.storageProvider__.write(newValue);
     },
     {receivePrevious: false}, // Only listen for *new* changes.
@@ -59,6 +59,20 @@ export class PersistentStateSignal<T extends JsonValue> extends StateSignal<T> {
       schemaVersion: config.schemaVersion,
       initialValue,
     });
+  }
+
+  /**
+   * Updates the signal's value.
+   *
+   * This method accepts the rich type `T` for developer convenience,
+   * immediately serializes it to `Jsonify<T>`, and then updates the
+   * signal's internal state.
+   *
+   * @param newValue The new rich value to set.
+   */
+  public override set(newValue: T | Jsonify<T>): void {
+    const serializedValue = this.storageProvider__.convertDataType(newValue);
+    super.set(serializedValue);
   }
 
   /**

--- a/packages/signal/src/core/persistent-state-signal.ts
+++ b/packages/signal/src/core/persistent-state-signal.ts
@@ -36,9 +36,12 @@ export class PersistentStateSignal<T extends JsonValue> extends StateSignal<T> {
   private readonly storageSyncSubscription__;
 
   constructor(config: PersistentStateSignalConfig<T>) {
+    config.storageKey ??= config.name;
+    config.saveDebounceDelay ??= 500;
+
     // 1. Create the LocalStorageProvider instance.
     const storageProvider = createLocalStorageProvider<T>({
-      name: config.name,
+      name: config.storageKey,
       schemaVersion: config.schemaVersion,
       defaultValue: config.defaultValue,
     });
@@ -63,7 +66,7 @@ export class PersistentStateSignal<T extends JsonValue> extends StateSignal<T> {
     this.storageProvider__ = storageProvider;
 
     this.storageDebouncer__ = createDebouncer({
-      delay: config.saveDebounceDelay ?? 500,
+      delay: config.saveDebounceDelay,
       leading: false,
       trailing: true,
       thisContext: this,

--- a/packages/signal/src/core/persistent-state-signal.ts
+++ b/packages/signal/src/core/persistent-state-signal.ts
@@ -14,7 +14,7 @@ import type {LocalStorageProvider} from '@alwatr/local-storage';
  *
  * @template T The type of the state it holds.
  */
-export class PersistentStateSignal<T> extends StateSignal<Jsonify<T>> {
+export class PersistentStateSignal<T extends JsonValue> extends StateSignal<T> {
   /**
    * The underlying storage provider instance.
    * @private
@@ -77,43 +77,9 @@ export class PersistentStateSignal<T> extends StateSignal<Jsonify<T>> {
    * Syncs the new value to storage.
    * @param newValue The new value to sync to storage.
    */
-  private syncStorage__(newValue: Jsonify<T>): void {
+  private syncStorage__(newValue: T): void {
     this.logger_.logMethodArgs?.('syncStorage__', newValue);
     this.storageProvider__.write(newValue);
-  }
-
-  /**
-   * Updates the signal's value.
-   *
-   * This method accepts the rich type `T` for developer convenience,
-   * immediately serializes it to `Jsonify<T>`, and then updates the
-   * signal's internal state.
-   *
-   * @param newValue The new rich value to set.
-   * @param convertDataType If true, converts `newValue` from `T` to `Jsonify<T>`.
-   *                        Default is false, meaning `newValue` is already `Jsonify<T>`.
-   */
-  public override set(newValue: Jsonify<T>): void;
-
-  /**
-   * Updates the signal's value.
-   *
-   * This method accepts the rich type `T` for developer convenience,
-   * immediately serializes it to `Jsonify<T>`, and then updates the
-   * signal's internal state.
-   *
-   * @param newValue The new rich value to set.
-   * @param convertDataType If true, converts `newValue` from `T` to `Jsonify<T>`.
-   *                        Default is false, meaning `newValue` is already `Jsonify<T>`.
-   */
-  public override set(newValue: T | Jsonify<T>, convertDataType: true): void;
-  public override set(newValue: T | Jsonify<T>, convertDataType?: true): void {
-    if (convertDataType === true) {
-      super.set(this.storageProvider__.convertDataType(newValue as T));
-    }
-    else {
-      super.set(newValue as Jsonify<T>);
-    }
   }
 
   /**

--- a/packages/signal/src/core/state-signal.ts
+++ b/packages/signal/src/core/state-signal.ts
@@ -52,7 +52,10 @@ export class StateSignal<T> extends SignalBase<T> implements IReadonlySignal<T> 
   protected logger_ = createLogger(`state-signal:${this.name}`);
 
   constructor(config: StateSignalConfig<T>) {
-    super(config);
+    super({
+      name: config.name,
+      onDestroy: config.onDestroy,
+    });
     this.value__ = config.initialValue;
     this.logger_.logMethodArgs?.('constructor', {initialValue: this.value__});
   }

--- a/packages/signal/src/creators/persistent-state.ts
+++ b/packages/signal/src/creators/persistent-state.ts
@@ -1,0 +1,33 @@
+import {PersistentStateSignal} from '../core/persistent-state-signal.js';
+
+import type {PersistentStateSignalConfig} from '../type.js';
+
+/**
+ * Creates a stateful signal that persists its value in localStorage.
+ *
+ * This function provides a clean, declarative API for creating state that
+ * survives page reloads. It automatically handles reading the initial state
+ * from localStorage and saving subsequent updates.
+ *
+ * @template T The type of the state it holds.
+ *
+ * @param {PersistentStateSignalConfig<T>} config The configuration for the persistent state signal.
+ * @returns {PersistentStateSignal<T>} A new instance of PersistentStateSignal.
+ *
+ * @example
+ * // Create a signal to store user's preferred theme.
+ * const userThemeSignal = createPersistentStateSignal<string>({
+ *   name: 'user-theme',
+ *   schemaVersion: 1,
+ *   defaultValue: 'light',
+ * });
+ *
+ * // The initial value is read from localStorage, or 'light' if not present.
+ * console.log(userThemeSignal.get());
+ *
+ * // Setting a new value updates the in-memory state and writes to localStorage.
+ * userThemeSignal.set('dark');
+ */
+export function createPersistentStateSignal<T extends JsonValue>(config: PersistentStateSignalConfig<T>): PersistentStateSignal<T> {
+  return new PersistentStateSignal(config);
+}

--- a/packages/signal/src/main.ts
+++ b/packages/signal/src/main.ts
@@ -3,12 +3,16 @@ export * from './core/event-signal.js';
 export * from './core/state-signal.js';
 export * from './core/computed-signal.js';
 export * from './core/effect-signal.js';
+export * from './core/persistent-state-signal.js';
 
 export * from './creators/event.js';
 export * from './creators/state.js';
 export * from './creators/computed.js';
 export * from './creators/effect.js';
+export * from './creators/persistent-state.js';
 
 export * from './operators/debounce.js';
+export * from './operators/filter.js';
+export * from './operators/map.js';
 
 export type * from './type.js';

--- a/packages/signal/src/type.ts
+++ b/packages/signal/src/type.ts
@@ -1,4 +1,5 @@
 import type {DebouncerConfig} from '@alwatr/debounce';
+import type {LocalStorageProviderConfig} from '@alwatr/local-storage';
 import type {} from '@alwatr/type-helper';
 
 /**
@@ -309,3 +310,11 @@ export interface DebounceSignalConfig extends Omit<DebouncerConfig<never>, 'func
    */
   onDestroy?: () => void;
 }
+
+/**
+ * Configuration for a persistent state signal.
+ * It combines the core signal configuration with the necessary options for local storage persistence.
+ *
+ * @template T The type of the state it holds.
+ */
+export interface PersistentStateSignalConfig<T> extends SignalConfig, LocalStorageProviderConfig<T> {}

--- a/packages/signal/src/type.ts
+++ b/packages/signal/src/type.ts
@@ -317,4 +317,12 @@ export interface DebounceSignalConfig extends Omit<DebouncerConfig<never>, 'func
  *
  * @template T The type of the state it holds.
  */
-export interface PersistentStateSignalConfig<T> extends SignalConfig, LocalStorageProviderConfig<T> {}
+export interface PersistentStateSignalConfig<T> extends SignalConfig, LocalStorageProviderConfig<T> {
+  /**
+   * The debounce delay (in milliseconds) for saving changes to localStorage.
+   * This helps to reduce the frequency of write operations, which can be costly in terms of performance.
+   * 
+   * @default 500
+   */
+  saveDebounceDelay?: number;
+}

--- a/packages/signal/src/type.ts
+++ b/packages/signal/src/type.ts
@@ -315,7 +315,7 @@ export interface DebounceSignalConfig extends Omit<DebouncerConfig<never>, 'func
  *
  * @template T The type of the state it holds.
  */
-export interface PersistentStateSignalConfig<T> extends SignalConfig, LocalStorageProviderConfig<T> {
+export interface PersistentStateSignalConfig<T extends JsonValue> extends SignalConfig, LocalStorageProviderConfig<T> {
   /**
    * The debounce delay (in milliseconds) for saving changes to localStorage.
    * This helps to reduce the frequency of write operations, which can be costly in terms of performance.

--- a/packages/signal/src/type.ts
+++ b/packages/signal/src/type.ts
@@ -253,7 +253,6 @@ export interface EffectSignalConfig {
 
   /**
    * If `true`, the effect's `run` function will be executed once immediately upon initialization.
-   *
    * @default false
    */
   runImmediately?: boolean;
@@ -299,7 +298,6 @@ export interface IEffectSignal {
 export interface DebounceSignalConfig extends Omit<DebouncerConfig<never>, 'func' | 'thisContext'> {
   /**
    * A unique identifier for the signal. This is crucial for debugging and differentiating signals.
-   *
    * @default `${sourceSignal.name}-debounced`
    */
   name?: string;
@@ -321,7 +319,6 @@ export interface PersistentStateSignalConfig<T> extends SignalConfig, LocalStora
   /**
    * The debounce delay (in milliseconds) for saving changes to localStorage.
    * This helps to reduce the frequency of write operations, which can be costly in terms of performance.
-   * 
    * @default 500
    */
   saveDebounceDelay?: number;

--- a/packages/signal/src/type.ts
+++ b/packages/signal/src/type.ts
@@ -317,6 +317,12 @@ export interface DebounceSignalConfig extends Omit<DebouncerConfig<never>, 'func
  */
 export interface PersistentStateSignalConfig<T extends JsonValue> extends SignalConfig, LocalStorageProviderConfig<T> {
   /**
+   * The key under which to store the signal's state in localStorage.
+   * @default ‍`signal-name`
+   */
+  storageKey?: string;
+
+  /**
    * The debounce delay (in milliseconds) for saving changes to localStorage.
    * This helps to reduce the frequency of write operations, which can be costly in terms of performance.
    * @default 500

--- a/packages/signal/src/type.ts
+++ b/packages/signal/src/type.ts
@@ -318,7 +318,7 @@ export interface DebounceSignalConfig extends Omit<DebouncerConfig<never>, 'func
 export interface PersistentStateSignalConfig<T extends JsonValue> extends SignalConfig, LocalStorageProviderConfig<T> {
   /**
    * The key under which to store the signal's state in localStorage.
-   * @default ‍`signal-name`
+   * @default `signal-name`
    */
   storageKey?: string;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,7 +82,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@alwatr/logger@npm:^6.0.5":
+"@alwatr/local-storage@npm:^6.1.8":
+  version: 6.1.8
+  resolution: "@alwatr/local-storage@npm:6.1.8"
+  dependencies:
+    "@alwatr/logger": "npm:6.0.5"
+  checksum: 10c0/44963de3ac2e07ec0476e30eb56494c08847c3f60d6a3ef2a0cb43c6e745fcf5e68d5a0406719a338f9d0bcad783928af4ba69b5beb4ae285bb605bc1d793e51
+  languageName: node
+  linkType: hard
+
+"@alwatr/logger@npm:6.0.5, @alwatr/logger@npm:^6.0.5":
   version: 6.0.5
   resolution: "@alwatr/logger@npm:6.0.5"
   dependencies:
@@ -133,6 +142,7 @@ __metadata:
   dependencies:
     "@alwatr/debounce": "npm:^1.1.6"
     "@alwatr/delay": "npm:^6.0.8"
+    "@alwatr/local-storage": "npm:^6.1.8"
     "@alwatr/logger": "npm:^6.0.5"
     "@alwatr/nano-build": "npm:^6.3.1"
     "@alwatr/prettier-config": "npm:^5.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,20 +5,20 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@alwatr/debounce@npm:^1.1.6":
-  version: 1.1.6
-  resolution: "@alwatr/debounce@npm:1.1.6"
-  checksum: 10c0/ab6073a6dbfd88d9d517a9bc70be26a2a11e9c7d85041a0feb688f2980753ceb12afe6b1de090b26b9470227ba2a696e0710e794a5d4d0cfefeb74621d6be98f
+"@alwatr/debounce@npm:^1.1.7":
+  version: 1.1.7
+  resolution: "@alwatr/debounce@npm:1.1.7"
+  checksum: 10c0/2c8c4cd2ac61944f2e4812dc8b09b18404c7d1158b6b358d5d268e7b108a7343d804628da1bd59f8d7e67a65f011a10cd2402b57515b0771334f74ba9a2e5c7c
   languageName: node
   linkType: hard
 
-"@alwatr/delay@npm:^6.0.8":
-  version: 6.0.8
-  resolution: "@alwatr/delay@npm:6.0.8"
+"@alwatr/delay@npm:^6.0.9":
+  version: 6.0.9
+  resolution: "@alwatr/delay@npm:6.0.9"
   dependencies:
-    "@alwatr/global-this": "npm:5.5.17"
-    "@alwatr/parse-duration": "npm:5.5.17"
-  checksum: 10c0/0469ac1dba540dcb2c976dd3f3298dbaa9601ff8769e03f4864b8baa297cb920c79e3a40895d5d0bcf95bbc4e16cccb5076d63cbb517776de80976d8ceb7ea23
+    "@alwatr/global-this": "npm:5.5.18"
+    "@alwatr/parse-duration": "npm:5.5.18"
+  checksum: 10c0/7473509e873e51926d1665be9d3bbc4145de9db68b03af53116a69551ce5efb4f478bba6fc22ab09b347cb2c91e5532bd89f9a2ce330f546d6e0614074dea471
   languageName: node
   linkType: hard
 
@@ -41,11 +41,11 @@ __metadata:
   resolution: "@alwatr/flux@workspace:packages/flux"
   dependencies:
     "@alwatr/fsm": "workspace:*"
-    "@alwatr/nano-build": "npm:^6.3.1"
+    "@alwatr/nano-build": "npm:^6.3.2"
     "@alwatr/prettier-config": "npm:^5.0.4"
     "@alwatr/signal": "workspace:*"
     "@alwatr/tsconfig-base": "npm:^6.0.2"
-    "@alwatr/type-helper": "npm:^6.1.1"
+    "@alwatr/type-helper": "npm:^6.1.2"
     "@types/node": "npm:^22.18.6"
     jest: "npm:^30.1.3"
     typescript: "npm:^5.9.2"
@@ -56,76 +56,76 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@alwatr/fsm@workspace:packages/fsm"
   dependencies:
-    "@alwatr/logger": "npm:^6.0.5"
-    "@alwatr/nano-build": "npm:^6.3.1"
+    "@alwatr/logger": "npm:^6.0.6"
+    "@alwatr/nano-build": "npm:^6.3.2"
     "@alwatr/prettier-config": "npm:^5.0.4"
     "@alwatr/signal": "workspace:*"
     "@alwatr/tsconfig-base": "npm:^6.0.2"
-    "@alwatr/type-helper": "npm:^6.1.1"
+    "@alwatr/type-helper": "npm:^6.1.2"
     "@types/node": "npm:^22.18.6"
     jest: "npm:^30.1.3"
     typescript: "npm:^5.9.2"
   languageName: unknown
   linkType: soft
 
-"@alwatr/global-this@npm:5.5.17":
-  version: 5.5.17
-  resolution: "@alwatr/global-this@npm:5.5.17"
-  checksum: 10c0/d08a7e6a46b3fcff0bd870eec39a341ad3fd1e4a668370ae26550207fbcfdf11f09686acf75032a467cc34595b197851187dc9fbd7899853ad60489f7a74d1a5
+"@alwatr/global-this@npm:5.5.18":
+  version: 5.5.18
+  resolution: "@alwatr/global-this@npm:5.5.18"
+  checksum: 10c0/c8f387302a009b66fd8ac04775dbfbb5056f8894afd44b4538f4fba70a37d5c1f0df49a52acc6f31d7b39294a18840a18954dbd3fc87db520081902d67274420
   languageName: node
   linkType: hard
 
-"@alwatr/is-number@npm:5.7.13":
-  version: 5.7.13
-  resolution: "@alwatr/is-number@npm:5.7.13"
-  checksum: 10c0/5b51fa26b52bf814fb86aec58446d18df2280cbd42c38cbaa4add0c0ba4b3d063b3d84abd4b08bfb885745bc79b2f0dcfbaf0795876d1d21b0b8c886b60a53e9
+"@alwatr/is-number@npm:5.7.14":
+  version: 5.7.14
+  resolution: "@alwatr/is-number@npm:5.7.14"
+  checksum: 10c0/baa58c54ad5d8b4c5ae3af01e64ba8f279eacb787d7c556ce81a5f34068c709bb0abcaac1765b9d75a59b509241a143b4a1871a506fee048465aa50f6408a4ac
   languageName: node
   linkType: hard
 
-"@alwatr/local-storage@npm:^6.1.8":
-  version: 6.1.8
-  resolution: "@alwatr/local-storage@npm:6.1.8"
+"@alwatr/local-storage@npm:^6.2.0":
+  version: 6.2.0
+  resolution: "@alwatr/local-storage@npm:6.2.0"
   dependencies:
-    "@alwatr/logger": "npm:6.0.5"
-  checksum: 10c0/44963de3ac2e07ec0476e30eb56494c08847c3f60d6a3ef2a0cb43c6e745fcf5e68d5a0406719a338f9d0bcad783928af4ba69b5beb4ae285bb605bc1d793e51
+    "@alwatr/logger": "npm:6.0.6"
+  checksum: 10c0/d6bbba20f2f3251e1eb50113ab5a3a44f37a8d9b2acaa68e98cc9213253322ec834d27ae3021f8e8f93385211a357658bb676ef42cae44a1241b3efb05ea791f
   languageName: node
   linkType: hard
 
-"@alwatr/logger@npm:6.0.5, @alwatr/logger@npm:^6.0.5":
-  version: 6.0.5
-  resolution: "@alwatr/logger@npm:6.0.5"
+"@alwatr/logger@npm:6.0.6, @alwatr/logger@npm:^6.0.6":
+  version: 6.0.6
+  resolution: "@alwatr/logger@npm:6.0.6"
   dependencies:
-    "@alwatr/global-this": "npm:5.5.17"
-    "@alwatr/platform-info": "npm:5.5.16"
-  checksum: 10c0/cbfab8d4f4a6aa55c36282a75fdf26f231b633301461b970e47f0653648389968d7784ee2b5b01795be5e9e470aed7dbc61909ba04545481643f209b518c4b41
+    "@alwatr/global-this": "npm:5.5.18"
+    "@alwatr/platform-info": "npm:5.5.17"
+  checksum: 10c0/006e06c8c0dc0ff39aa3b1c24d8f1a1236bf4e4b5fd8049272c11b1bd6d72ba9b133edfb2f9fd12d4a6b25eed668bf431b7b4cdcebde49e6dc899d8ee97221d7
   languageName: node
   linkType: hard
 
-"@alwatr/nano-build@npm:^6.3.1":
-  version: 6.3.1
-  resolution: "@alwatr/nano-build@npm:6.3.1"
+"@alwatr/nano-build@npm:^6.3.2":
+  version: 6.3.2
+  resolution: "@alwatr/nano-build@npm:6.3.2"
   dependencies:
     esbuild: "npm:^0.25.10"
     picocolors: "npm:^1.1.1"
   bin:
     nano-build: nano-build.cjs
-  checksum: 10c0/7596bb1525af7866ea0e760ca39478208649f7fcb8a30b6e380d0bf537a86c30d44a1c9ca94dcc8e744a5e23b075f5c91170747ece7a49d9d8ab73144eae2cb6
+  checksum: 10c0/7e9c50063a73f8adff9182e778e80c38d4fb7fae622b4fdea0e191d6dabe0a22c97e51ae1d335da91126a19eb69846b71de8e030c333c6e1192bf50249539d3b
   languageName: node
   linkType: hard
 
-"@alwatr/parse-duration@npm:5.5.17":
-  version: 5.5.17
-  resolution: "@alwatr/parse-duration@npm:5.5.17"
+"@alwatr/parse-duration@npm:5.5.18":
+  version: 5.5.18
+  resolution: "@alwatr/parse-duration@npm:5.5.18"
   dependencies:
-    "@alwatr/is-number": "npm:5.7.13"
-  checksum: 10c0/af334200619d54c5537938d06a54a42bd4b46d2ba6eeb3ceba271f323ffa909869e4fa1f4e360c5ed271d12b32cf6ef77def81874539a3d3edd033898f294ecf
+    "@alwatr/is-number": "npm:5.7.14"
+  checksum: 10c0/0984db92cfcf8132d7add600a2b7b9a1fa93b62fb6ee2cc93059c1fbd0377059e6f71bad75e63fd52dcc6d85e8bb00b7b0c38eeb1a6f968d755290b44aa6038a
   languageName: node
   linkType: hard
 
-"@alwatr/platform-info@npm:5.5.16":
-  version: 5.5.16
-  resolution: "@alwatr/platform-info@npm:5.5.16"
-  checksum: 10c0/0531f2d003207fc40fbdbbfcc85473a0e4c736a6e4da5724892738dba341676d73e035ddf0ed609a58d90fc9672bfffb010a547ec46a7cc3ca0c621d3d96d7b9
+"@alwatr/platform-info@npm:5.5.17":
+  version: 5.5.17
+  resolution: "@alwatr/platform-info@npm:5.5.17"
+  checksum: 10c0/078cda7404251c9818f5c3ac1f9b427575026bf06a0e9b42c36363a95717f9c2d2a887deff980ebf4b6e595664bc61065969c244355d4ffb23f24064be6894bd
   languageName: node
   linkType: hard
 
@@ -140,14 +140,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@alwatr/signal@workspace:packages/signal"
   dependencies:
-    "@alwatr/debounce": "npm:^1.1.6"
-    "@alwatr/delay": "npm:^6.0.8"
-    "@alwatr/local-storage": "npm:^6.1.8"
-    "@alwatr/logger": "npm:^6.0.5"
-    "@alwatr/nano-build": "npm:^6.3.1"
+    "@alwatr/debounce": "npm:^1.1.7"
+    "@alwatr/delay": "npm:^6.0.9"
+    "@alwatr/local-storage": "npm:^6.2.0"
+    "@alwatr/logger": "npm:^6.0.6"
+    "@alwatr/nano-build": "npm:^6.3.2"
     "@alwatr/prettier-config": "npm:^5.0.4"
     "@alwatr/tsconfig-base": "npm:^6.0.2"
-    "@alwatr/type-helper": "npm:^6.1.1"
+    "@alwatr/type-helper": "npm:^6.1.2"
     "@jest/globals": "npm:^30.1.2"
     "@types/node": "npm:^22.18.6"
     jest: "npm:^30.1.3"
@@ -162,19 +162,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@alwatr/type-helper@npm:^6.1.1":
-  version: 6.1.1
-  resolution: "@alwatr/type-helper@npm:6.1.1"
-  checksum: 10c0/f2a3b32e204a8623fee0e63c5ce16b28b6355c919927aede3597fb413205742dc7aacd17f2a14994f07643c639a04dcdd9d45250d53782216c56e736f52868b9
+"@alwatr/type-helper@npm:^6.1.2":
+  version: 6.1.2
+  resolution: "@alwatr/type-helper@npm:6.1.2"
+  checksum: 10c0/6ab296009845fb7d2939e3c721ba60ccb102879424de1cdb604a376d08708fb39017d3fd0677c684eebda74b3632214ef446d65353883ff480858c05fd21c822
   languageName: node
   linkType: hard
 
-"@alwatr/yarn-upgrade@npm:^1.0.10":
-  version: 1.0.10
-  resolution: "@alwatr/yarn-upgrade@npm:1.0.10"
+"@alwatr/yarn-upgrade@npm:^1.0.11":
+  version: 1.0.11
+  resolution: "@alwatr/yarn-upgrade@npm:1.0.11"
   bin:
     upd: dist/main.mjs
-  checksum: 10c0/3acb49bb3f918057c9d9390158df7740fea754c68c94bffdc866b51ebdc7e74e06e947bb17a8058a5553d462eaa8d41607f17883c75875a1164491f11757a9a4
+  checksum: 10c0/481af521d9a840b6b86317f8a57e018df4f7ad6558f3ef6ef2180b84e90a6e9991f491e18952fa56e902f288819024903d11068478fd79896c6985b6ee192986
   languageName: node
   linkType: hard
 
@@ -2682,7 +2682,7 @@ __metadata:
     "@alwatr/eslint-config": "npm:^5.6.2"
     "@alwatr/prettier-config": "npm:^5.0.4"
     "@alwatr/tsconfig-base": "npm:^6.0.2"
-    "@alwatr/yarn-upgrade": "npm:^1.0.10"
+    "@alwatr/yarn-upgrade": "npm:^1.0.11"
     "@lerna-lite/changed": "npm:^4.8.0"
     "@lerna-lite/cli": "npm:^4.8.0"
     "@lerna-lite/diff": "npm:^4.8.0"
@@ -6305,21 +6305,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minizlib@npm:^3.0.1":
+"minizlib@npm:^3.0.1, minizlib@npm:^3.1.0":
   version: 3.1.0
   resolution: "minizlib@npm:3.1.0"
   dependencies:
     minipass: "npm:^7.1.2"
   checksum: 10c0/5aad75ab0090b8266069c9aabe582c021ae53eb33c6c691054a13a45db3b4f91a7fb1bd79151e6b4e9e9a86727b522527c0a06ec7d45206b745d54cd3097bcec
-  languageName: node
-  linkType: hard
-
-"mkdirp@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "mkdirp@npm:3.0.1"
-  bin:
-    mkdirp: dist/cjs/src/bin.js
-  checksum: 10c0/9f2b975e9246351f5e3a40dcfac99fcd0baa31fbfab615fe059fb11e51f10e4803c63de1f384c54d656e4db31d000e4767e9ef076a22e12a641357602e31d57d
   languageName: node
   linkType: hard
 
@@ -7809,16 +7800,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.4.3":
-  version: 7.4.3
-  resolution: "tar@npm:7.4.3"
+  version: 7.4.4
+  resolution: "tar@npm:7.4.4"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
-    minizlib: "npm:^3.0.1"
-    mkdirp: "npm:^3.0.1"
+    minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/d4679609bb2a9b48eeaf84632b6d844128d2412b95b6de07d53d8ee8baf4ca0857c9331dfa510390a0727b550fd543d4d1a10995ad86cdf078423fbb8d99831d
+  checksum: 10c0/2db46a140095488ed3244ac748f8e4f9362223b212bcae7859840dd9fd9891bc713f243d122906ce2f28eb64b49fa8cefc13cbdda24e66e8f2a5936a7c392b06
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,20 +5,20 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@alwatr/debounce@npm:^1.1.7":
-  version: 1.1.7
-  resolution: "@alwatr/debounce@npm:1.1.7"
-  checksum: 10c0/2c8c4cd2ac61944f2e4812dc8b09b18404c7d1158b6b358d5d268e7b108a7343d804628da1bd59f8d7e67a65f011a10cd2402b57515b0771334f74ba9a2e5c7c
+"@alwatr/debounce@npm:^1.1.8":
+  version: 1.1.8
+  resolution: "@alwatr/debounce@npm:1.1.8"
+  checksum: 10c0/ad5b550cf60cb393e756190193e1f668bf323da890ddcbe5c1eeff15aa5ad7f88a794928ba6e88911aa9f467a3d9af1b1992151ff03bd4b4a32a2b6666f2fe16
   languageName: node
   linkType: hard
 
-"@alwatr/delay@npm:^6.0.9":
-  version: 6.0.9
-  resolution: "@alwatr/delay@npm:6.0.9"
+"@alwatr/delay@npm:^6.0.10":
+  version: 6.0.10
+  resolution: "@alwatr/delay@npm:6.0.10"
   dependencies:
-    "@alwatr/global-this": "npm:5.5.18"
-    "@alwatr/parse-duration": "npm:5.5.18"
-  checksum: 10c0/7473509e873e51926d1665be9d3bbc4145de9db68b03af53116a69551ce5efb4f478bba6fc22ab09b347cb2c91e5532bd89f9a2ce330f546d6e0614074dea471
+    "@alwatr/global-this": "npm:5.5.19"
+    "@alwatr/parse-duration": "npm:5.5.19"
+  checksum: 10c0/f90395114a16f08fd66177ae5aae5f1e8206e55aba87acf8be0f660b8b5b62c998db07417cd18ad3abb7948b658278b756350fe62d9e95eaab5d6f53ed5307d1
   languageName: node
   linkType: hard
 
@@ -56,7 +56,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@alwatr/fsm@workspace:packages/fsm"
   dependencies:
-    "@alwatr/logger": "npm:^6.0.6"
+    "@alwatr/logger": "npm:^6.0.7"
     "@alwatr/nano-build": "npm:^6.3.2"
     "@alwatr/prettier-config": "npm:^5.0.4"
     "@alwatr/signal": "workspace:*"
@@ -68,64 +68,64 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@alwatr/global-this@npm:5.5.18":
-  version: 5.5.18
-  resolution: "@alwatr/global-this@npm:5.5.18"
-  checksum: 10c0/c8f387302a009b66fd8ac04775dbfbb5056f8894afd44b4538f4fba70a37d5c1f0df49a52acc6f31d7b39294a18840a18954dbd3fc87db520081902d67274420
+"@alwatr/global-this@npm:5.5.19":
+  version: 5.5.19
+  resolution: "@alwatr/global-this@npm:5.5.19"
+  checksum: 10c0/42b0cf8fd285f175051a6410faf6dcb4fcad679196796579ce389c88ff3f0d625e51f6b8709dd8c2d702ba9593c8c34641959defa1b07259f52f1077132aec44
   languageName: node
   linkType: hard
 
-"@alwatr/is-number@npm:5.7.14":
-  version: 5.7.14
-  resolution: "@alwatr/is-number@npm:5.7.14"
-  checksum: 10c0/baa58c54ad5d8b4c5ae3af01e64ba8f279eacb787d7c556ce81a5f34068c709bb0abcaac1765b9d75a59b509241a143b4a1871a506fee048465aa50f6408a4ac
+"@alwatr/is-number@npm:5.7.15":
+  version: 5.7.15
+  resolution: "@alwatr/is-number@npm:5.7.15"
+  checksum: 10c0/7c4ef611ba891807a0ca0d4cb0e4b2e392208acdc0182b69df203750f20973257821f71548918b189e3c079ae106cba61d53c2f6d677ef81c25fa6c72d701a80
   languageName: node
   linkType: hard
 
-"@alwatr/local-storage@npm:^6.3.0":
-  version: 6.3.0
-  resolution: "@alwatr/local-storage@npm:6.3.0"
+"@alwatr/local-storage@npm:^6.3.3":
+  version: 6.3.3
+  resolution: "@alwatr/local-storage@npm:6.3.3"
   dependencies:
-    "@alwatr/logger": "npm:6.0.6"
-  checksum: 10c0/569f9fefc988ea7c0a9ac076b35ef8ef2492677ebae21b62539275caae5f1f127adcedd736bc71de892f8c9aca6a13eac310d6756d14888d640118e207a4d616
+    "@alwatr/logger": "npm:6.0.7"
+  checksum: 10c0/de970df082297f5347d58eda9d2c73b65702fc49ed8341b97714572ceadb8f74fd95caa85c9623cd0b3db65e969fa0cb8381bc480a63d0f23b719502b73d844e
   languageName: node
   linkType: hard
 
-"@alwatr/logger@npm:6.0.6, @alwatr/logger@npm:^6.0.6":
-  version: 6.0.6
-  resolution: "@alwatr/logger@npm:6.0.6"
+"@alwatr/logger@npm:6.0.7, @alwatr/logger@npm:^6.0.7":
+  version: 6.0.7
+  resolution: "@alwatr/logger@npm:6.0.7"
   dependencies:
-    "@alwatr/global-this": "npm:5.5.18"
-    "@alwatr/platform-info": "npm:5.5.17"
-  checksum: 10c0/006e06c8c0dc0ff39aa3b1c24d8f1a1236bf4e4b5fd8049272c11b1bd6d72ba9b133edfb2f9fd12d4a6b25eed668bf431b7b4cdcebde49e6dc899d8ee97221d7
+    "@alwatr/global-this": "npm:5.5.19"
+    "@alwatr/platform-info": "npm:5.5.18"
+  checksum: 10c0/a3d5a1583d37ba98705d649c6fbf9ddec1853e2f13b7d60d5189b092d66f550b65d09326afa423bbcdde26a4095c78df2256fbfebd8ae8bf131bbf81c10e220b
   languageName: node
   linkType: hard
 
 "@alwatr/nano-build@npm:^6.3.2":
-  version: 6.3.2
-  resolution: "@alwatr/nano-build@npm:6.3.2"
+  version: 6.3.3
+  resolution: "@alwatr/nano-build@npm:6.3.3"
   dependencies:
     esbuild: "npm:^0.25.10"
     picocolors: "npm:^1.1.1"
   bin:
     nano-build: nano-build.cjs
-  checksum: 10c0/7e9c50063a73f8adff9182e778e80c38d4fb7fae622b4fdea0e191d6dabe0a22c97e51ae1d335da91126a19eb69846b71de8e030c333c6e1192bf50249539d3b
+  checksum: 10c0/888a0b026151ec75d790d27c25a8418f6d3d33e48b974129f786d7eeb99b4b04d5b8aa2433c836c0b6dec3e61d86aa9fa77b7a8802a05671f2d49ecc303dab0c
   languageName: node
   linkType: hard
 
-"@alwatr/parse-duration@npm:5.5.18":
-  version: 5.5.18
-  resolution: "@alwatr/parse-duration@npm:5.5.18"
+"@alwatr/parse-duration@npm:5.5.19":
+  version: 5.5.19
+  resolution: "@alwatr/parse-duration@npm:5.5.19"
   dependencies:
-    "@alwatr/is-number": "npm:5.7.14"
-  checksum: 10c0/0984db92cfcf8132d7add600a2b7b9a1fa93b62fb6ee2cc93059c1fbd0377059e6f71bad75e63fd52dcc6d85e8bb00b7b0c38eeb1a6f968d755290b44aa6038a
+    "@alwatr/is-number": "npm:5.7.15"
+  checksum: 10c0/4f61bcf6084719d7605eccc6c488211641c347f889bb7afde24207e14c38eb59ab6514234a79957292a72abde9f6af7249c88e2075e42371d8a1a329199916cb
   languageName: node
   linkType: hard
 
-"@alwatr/platform-info@npm:5.5.17":
-  version: 5.5.17
-  resolution: "@alwatr/platform-info@npm:5.5.17"
-  checksum: 10c0/078cda7404251c9818f5c3ac1f9b427575026bf06a0e9b42c36363a95717f9c2d2a887deff980ebf4b6e595664bc61065969c244355d4ffb23f24064be6894bd
+"@alwatr/platform-info@npm:5.5.18":
+  version: 5.5.18
+  resolution: "@alwatr/platform-info@npm:5.5.18"
+  checksum: 10c0/dbf7886a281e6d3a20817563c4bf54f4df66007d4becd05bd74271090650a0df6fcaaaa27e45395012793e20203463bb537508541a36affb2b825d28869acd92
   languageName: node
   linkType: hard
 
@@ -140,10 +140,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@alwatr/signal@workspace:packages/signal"
   dependencies:
-    "@alwatr/debounce": "npm:^1.1.7"
-    "@alwatr/delay": "npm:^6.0.9"
-    "@alwatr/local-storage": "npm:^6.3.0"
-    "@alwatr/logger": "npm:^6.0.6"
+    "@alwatr/debounce": "npm:^1.1.8"
+    "@alwatr/delay": "npm:^6.0.10"
+    "@alwatr/local-storage": "npm:^6.3.3"
+    "@alwatr/logger": "npm:^6.0.7"
     "@alwatr/nano-build": "npm:^6.3.2"
     "@alwatr/prettier-config": "npm:^5.0.4"
     "@alwatr/tsconfig-base": "npm:^6.0.2"
@@ -163,18 +163,18 @@ __metadata:
   linkType: hard
 
 "@alwatr/type-helper@npm:^6.1.2":
-  version: 6.1.2
-  resolution: "@alwatr/type-helper@npm:6.1.2"
-  checksum: 10c0/6ab296009845fb7d2939e3c721ba60ccb102879424de1cdb604a376d08708fb39017d3fd0677c684eebda74b3632214ef446d65353883ff480858c05fd21c822
+  version: 6.1.3
+  resolution: "@alwatr/type-helper@npm:6.1.3"
+  checksum: 10c0/2bcb1470c854af5a546732ff447acfe939ad72f1c152e35966670ea2452cce1c15f1846f8143ad8535002ac1739d36a0eb2d5821fd159060f80f0ce6429de960
   languageName: node
   linkType: hard
 
-"@alwatr/yarn-upgrade@npm:^1.0.11":
-  version: 1.0.11
-  resolution: "@alwatr/yarn-upgrade@npm:1.0.11"
+"@alwatr/yarn-upgrade@npm:^1.0.12":
+  version: 1.0.12
+  resolution: "@alwatr/yarn-upgrade@npm:1.0.12"
   bin:
     upd: dist/main.mjs
-  checksum: 10c0/481af521d9a840b6b86317f8a57e018df4f7ad6558f3ef6ef2180b84e90a6e9991f491e18952fa56e902f288819024903d11068478fd79896c6985b6ee192986
+  checksum: 10c0/5463388f7c89f9fe49caf5ccc9287407161e1e0d426b0834975d5cfca4b1dad282c314685ce32d01ff9915de2fdc4d55c58620bef0c086f3b47a61777a7515f5
   languageName: node
   linkType: hard
 
@@ -2682,7 +2682,7 @@ __metadata:
     "@alwatr/eslint-config": "npm:^5.6.2"
     "@alwatr/prettier-config": "npm:^5.0.4"
     "@alwatr/tsconfig-base": "npm:^6.0.2"
-    "@alwatr/yarn-upgrade": "npm:^1.0.11"
+    "@alwatr/yarn-upgrade": "npm:^1.0.12"
     "@lerna-lite/changed": "npm:^4.8.0"
     "@lerna-lite/cli": "npm:^4.8.0"
     "@lerna-lite/diff": "npm:^4.8.0"
@@ -6491,11 +6491,12 @@ __metadata:
   linkType: hard
 
 "npm-packlist@npm:^10.0.1":
-  version: 10.0.1
-  resolution: "npm-packlist@npm:10.0.1"
+  version: 10.0.2
+  resolution: "npm-packlist@npm:10.0.2"
   dependencies:
     ignore-walk: "npm:^8.0.0"
-  checksum: 10c0/64397de9e1c8c90d63dfb37604a49e642106f086ebc84d1b1fc7519e35d7c599a246bb75396d5b62f307e35e849c879aebf5f6da505453d7f2d619cf5362d8b3
+    proc-log: "npm:^5.0.0"
+  checksum: 10c0/55d6e8a158278c23105d39959db002c4b7453096470ba2942c544fe0cbc0c66621201ea3ef0199d4039bfe6a22ea444da6fbe9085fc4f9085e9d2a675623c1bc
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,12 +82,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@alwatr/local-storage@npm:^6.2.0":
-  version: 6.2.0
-  resolution: "@alwatr/local-storage@npm:6.2.0"
+"@alwatr/local-storage@npm:^6.3.0":
+  version: 6.3.0
+  resolution: "@alwatr/local-storage@npm:6.3.0"
   dependencies:
     "@alwatr/logger": "npm:6.0.6"
-  checksum: 10c0/d6bbba20f2f3251e1eb50113ab5a3a44f37a8d9b2acaa68e98cc9213253322ec834d27ae3021f8e8f93385211a357658bb676ef42cae44a1241b3efb05ea791f
+  checksum: 10c0/569f9fefc988ea7c0a9ac076b35ef8ef2492677ebae21b62539275caae5f1f127adcedd736bc71de892f8c9aca6a13eac310d6756d14888d640118e207a4d616
   languageName: node
   linkType: hard
 
@@ -142,7 +142,7 @@ __metadata:
   dependencies:
     "@alwatr/debounce": "npm:^1.1.7"
     "@alwatr/delay": "npm:^6.0.9"
-    "@alwatr/local-storage": "npm:^6.2.0"
+    "@alwatr/local-storage": "npm:^6.3.0"
     "@alwatr/logger": "npm:^6.0.6"
     "@alwatr/nano-build": "npm:^6.3.2"
     "@alwatr/prettier-config": "npm:^5.0.4"


### PR DESCRIPTION
Add a new dependency for local storage and implement PersistentStateSignal for managing state persistence in localStorage. Update the StateSignal constructor to accommodate new configuration parameters. Introduce a helper function to create persistent state signals easily.